### PR TITLE
Odd number of electrons + newton postponed

### DIFF
--- a/my_dmet/fragments.py
+++ b/my_dmet/fragments.py
@@ -776,8 +776,8 @@ class fragment_object:
     ###############################################################################################################################
     def get_guess_1RDM (self, chempot_imp):
         FOCK = represent_operator_in_basis (self.ints.activeFOCK, self.loc2imp) - chempot_imp
-        guess_1RDM = [get_1RDM_from_OEI (FOCK, (self.nelec_imp // 2) + self.target_MS),
-                      get_1RDM_from_OEI (FOCK, (self.nelec_imp // 2) - self.target_MS)]
+        guess_1RDM = [get_1RDM_from_OEI (FOCK,int ( round ( (self.nelec_imp // 2) + self.target_MS))),
+                      get_1RDM_from_OEI (FOCK,int ( round ( (self.nelec_imp // 2) - self.target_MS)))]
         if not self.target_MS: guess_1RDM = guess_1RDM[0] + guess_1RDM[1]
         return guess_1RDM
 

--- a/my_dmet/main_object.py
+++ b/my_dmet/main_object.py
@@ -1006,12 +1006,11 @@ class dmet:
 
         nelec_wmas_current = sum ([f.nelec_as for f in self.fragments if f.norbs_as > 0])
         norbs_wmas_current = sum ([f.norbs_as for f in self.fragments if f.norbs_as > 0])
-        assert ((self.ints.nelec_tot - nelec_wmas_current) % 2 == 0), 'parity problem: {} of {} electrons active in currently'.format (nelec_wmas_target, self.ints.nelec_tot)
-        ncore_current = (self.ints.nelec_tot - nelec_wmas_current) // 2
-        nocc_current = ncore_current + norbs_wmas_current
-        print ("ncore_current = {}; nocc_current = {}".format (ncore_current, nocc_current))
-
         if norbs_wmas_current > 0:
+            assert ((self.ints.nelec_tot - nelec_wmas_current) % 2 == 0), 'parity problem: {} of {} electrons active in currently'.format (nelec_wmas_current, self.ints.nelec_tot)
+            ncore_current = (self.ints.nelec_tot - nelec_wmas_current) // 2
+            nocc_current = ncore_current + norbs_wmas_current
+            print ("ncore_current = {}; nocc_current = {}".format (ncore_current, nocc_current))
             wmas2ao_current = (self.ints.ao2loc @ loc2wmas_current).conjugate ().T
             amo_coeff = mo_coeff[:,ncore_current:nocc_current]
             ovlp = wmas2ao_current @ self.ints.ao_ovlp @ amo_coeff
@@ -1019,6 +1018,9 @@ class dmet:
             assert (np.isclose (ovlp, 1)), 'unless replace=True, mo_coeff must contain current active orbitals at range {}:{} (err={})'.format (ncore_current,nocc_current, ovlp-1)
             if caslst is not None and len (caslst) > 0:
                 assert (np.all (np.isin (list(range(ncore_current+1,nocc_current+1)), caslst))), 'caslst must contain range {}:{} inclusive ({})'.format (ncore_current+1, nocc_current, caslst)
+        else:
+            ncore_current = nocc_current =(self.ints.nelec_tot+1)//2
+
 
         if caslst is not None and len (caslst) == 0: caslst = None
         if caslst is not None and cas_irrep_nocc is not None:

--- a/my_dmet/pyscf_casscf.py
+++ b/my_dmet/pyscf_casscf.py
@@ -224,17 +224,7 @@ def solve (frag, guess_1RDM, chempot_imp):
 
     t_start = time.time()
     E_CASSCF = mc.kernel(imp2mo, ci0)[0]
-    if not mc.converged:
-        print ('Restarting another first order mc solver...')  ##RP added another attempt at a 1st order solver with the same number of iterations before we go to the newton solver. 
-        imp2mo = mc.mo_coeff.copy ()
-        mc = mcscf.CASSCF(mf, CASorb, CASe)
-        smult = abs_2S + 1 if frag.target_S is not None else (frag.nelec_imp % 2) + 1
-        mc.fcisolver = csf_solver (mf.mol, smult)
-        E_CASSCF = mc.kernel(imp2mo)[0]
-
-    if not mc.converged:
-        if np.any (np.abs (frag.impham_OEI_S) > 1e-8):
-            raise NotImplementedError('Gradient and Hessian fixes for nonsinglet environment of Newton-descent CASSCF algorithm')
+    if not ( mc.converged and np.all (np.abs (frag.impham_OEI_S) < 1e-8) ):
         mc = mc.newton ()
         E_CASSCF = mc.kernel(mc.mo_coeff, mc.ci)[0]
     if not mc.converged:
@@ -245,6 +235,8 @@ def solve (frag, guess_1RDM, chempot_imp):
         mc.fcisolver = csf_solver (mf.mol, smult)
         E_CASSCF = mc.kernel(imp2mo)[0]
         if not mc.converged:
+            if np.any (np.abs (frag.impham_OEI_S) > 1e-8):
+                raise NotImplementedError('Gradient and Hessian fixes for nonsinglet environment of Newton-descent CASSCF algorithm')
             mc = mc.newton ()
             E_CASSCF = mc.kernel(mc.mo_coeff, mc.ci)[0]
     assert (mc.converged)

--- a/my_dmet/pyscf_casscf.py
+++ b/my_dmet/pyscf_casscf.py
@@ -225,6 +225,14 @@ def solve (frag, guess_1RDM, chempot_imp):
     t_start = time.time()
     E_CASSCF = mc.kernel(imp2mo, ci0)[0]
     if not mc.converged:
+        print ('Restarting another first order mc solver...')  ##RP added another attempt at a 1st order solver with the same number of iterations before we go to the newton solver. 
+        imp2mo = mc.mo_coeff.copy ()
+        mc = mcscf.CASSCF(mf, CASorb, CASe)
+        smult = abs_2S + 1 if frag.target_S is not None else (frag.nelec_imp % 2) + 1
+        mc.fcisolver = csf_solver (mf.mol, smult)
+        E_CASSCF = mc.kernel(imp2mo)[0]
+
+    if not mc.converged:
         if np.any (np.abs (frag.impham_OEI_S) > 1e-8):
             raise NotImplementedError('Gradient and Hessian fixes for nonsinglet environment of Newton-descent CASSCF algorithm')
         mc = mc.newton ()

--- a/my_dmet/qcdmethelper.py
+++ b/my_dmet/qcdmethelper.py
@@ -31,7 +31,7 @@ class qcdmethelper:
     def __init__( self, theLocalIntegrals, list_H1, altcf, minFunc ):
     
         self.locints = theLocalIntegrals
-        assert( self.locints.nelec_tot % 2 == 0 )
+        #assert( self.locints.nelec_tot % 2 == 0 )
         self.numPairs = int (self.locints.nelec_tot / 2)
         self.altcf = altcf
         self.minFunc = None


### PR DESCRIPTION
Code now works for odd number of electrrons (Tested only with Confine guess=True and with guess_somos specifying where the unpaired electron(s) are. Also, the code now does not go to a newton solver immediately after the first order solver fails. It does another first order without taking the ci vectors from the previous. Has been observed to work in a few systems.