### PR TITLE
Allow user-defined cint directory in CMakeLists.txt

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -75,6 +75,7 @@ else ()
 endif ()
 include_directories(${PYSCFLIB})
 include_directories(${PYSCFLIB}/deps/include)
+include_directories(${CINT_DIR}/include)
 link_directories(${PYSCFLIB})
 
 # Build the QC-DMET shared library


### PR DESCRIPTION
This problem has been mentioned by #12 .When libcint is in a location other than `${PYSCFLIB}/deps`, the compiler cannot found `cint.h`. So I add `${CINT_DIR}/include` in CMakeLists.txt. Thus user can go with `cmake .. -DCINT_DIR=/path/to/libcint`