### PR TITLE
np version check fix

### DIFF
--- a/lib/helper.py
+++ b/lib/helper.py
@@ -1,10 +1,16 @@
 import sys, os
 import numpy
 
+
+def version_tuple(version):
+    return tuple(map(int, version.split('.')))
+
+
 ''' This bit copied from PySCF '''
 def load_library(libname):
 # numpy 1.6 has bug in ctypeslib.load_library, see numpy/distutils/misc_util.py
-    if '1.6' in numpy.__version__:
+    if version_tuple(numpy.__version__) <= version_tuple('1.6'):
+    #if '1.6' in numpy.__version__:
         if (sys.platform.startswith('linux') or
             sys.platform.startswith('gnukfreebsd')):
             so_ext = '.so'

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -9,7 +9,7 @@ def version_tuple(version):
 ''' This bit copied from PySCF '''
 def load_library(libname):
 # numpy 1.6 has bug in ctypeslib.load_library, see numpy/distutils/misc_util.py
-    if version_tuple(numpy.__version__) <= version_tuple('1.6'):
+    if version_tuple(numpy.__version__) <= version_tuple('1.6.2'):
     #if '1.6' in numpy.__version__:
         if (sys.platform.startswith('linux') or
             sys.platform.startswith('gnukfreebsd')):

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -3,14 +3,13 @@ import numpy
 
 
 def version_tuple(version):
-    return tuple(map(int, version.split('.')))
+    return tuple(map(int, version.split('.')))[:2]
 
 
 ''' This bit copied from PySCF '''
 def load_library(libname):
 # numpy 1.6 has bug in ctypeslib.load_library, see numpy/distutils/misc_util.py
-    if version_tuple(numpy.__version__) <= version_tuple('1.6.2'):
-    #if '1.6' in numpy.__version__:
+    if version_tuple(numpy.__version__) == version_tuple('1.6.2'):
         if (sys.platform.startswith('linux') or
             sys.platform.startswith('gnukfreebsd')):
             so_ext = '.so'


### PR DESCRIPTION
The load_library(libname) function at https://github.com/MatthewRHermes/mrh/blob/master/lib/helper.py has a weird way of checking the np version. Like, if condition is becoming true if np version is 1.21.6.

In this PR, I am adding a fix to make it consistent so that this condition becomes true for the np version less than or equal to the 1.6. 

Thank You

