### PR TITLE
Adding keyword to plot only active space orbitals

### DIFF
--- a/my_pyscf/tools/molden.py
+++ b/my_pyscf/tools/molden.py
@@ -41,9 +41,13 @@ def from_si_mcscf (mc, fname, state=None, si=None, cas_natorb=False, cas_mo_ener
         return from_sa_mcscf (mc, fname, state=state, cas_natorb=cas_natorb,
                               cas_mo_energy=cas_mo_energy, **kwargs)
 
-def from_lasscf (las, fname, state=None, natorb_casdm1=None, **kwargs):
+def from_lasscf (las, fname, state=None, natorb_casdm1=None, only_as=False, **kwargs):
     if state is not None: natorb_casdm1 = las.states_make_casdm1s ()[state].sum (0)
     mo_coeff, mo_ene, mo_occ = las.canonicalize (natorb_casdm1=natorb_casdm1)[:3]
+    if only_as:
+        mo_coeff = mo_coeff[:, las.ncore:las.ncore+las.ncas]
+        mo_ene = mo_ene[las.ncore:las.ncore+las.ncas]
+        mo_occ = mo_occ[las.ncore:las.ncore+las.ncas]
     return from_mo (las.mol, fname, mo_coeff, occ=mo_occ, ene=mo_ene, **kwargs)
 
 def from_lassi (lsi, fname, state=0, si=None, opt=1, **kwargs):


### PR DESCRIPTION
Adding feature to plot only active space orbitals. 

I am not adding example input or any unit test for this.
 
Here is the test input for your ref,

import numpy as np
from pyscf.fci import direct_spin1
from pyscf import gto, scf, tools, mcscf
from mrh.my_pyscf import lassi
from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
from mrh.my_pyscf.mcscf import lasscf_async as asyn
from mrh.my_pyscf.gto import ANO_RCC_VDZP
from mrh.my_pyscf.fci import csf_solver
from pyscf.mcpdft import _dms

mol = gto.Mole()
mol.atom = '''
   C       -6.62503        0.66598       -0.00000
   C       -5.55772        1.47246        0.00000
   C       -4.20292        0.97938       -0.00000
   C       -3.13491        1.78525       -0.00000
   H       -4.05251       -0.09825       -0.00000
   H       -3.22624        2.86669        0.00000
   H       -2.13208        1.36977       -0.00000
   H       -7.62813        1.08079        0.00000
   H       -6.53311       -0.41542       -0.00000
   H       -5.70837        2.55003        0.00000
'''
mol.basis='sto3g'
mol.verbose = 3
mol.build()

mf = scf.ROHF(mol)
mf.max_cycle=100
mf.kernel()

las = asyn.LASSCF (mf, (2,2), (2, 2), spin_sub=(1, 1))
frag_atom_list = ([0, 1], [2, 3])
mo0 = las.set_fragments_ (frag_atom_list, mf.mo_coeff)
las.max_cycle_macro = 100
las.kernel (mo0)

from mrh.my_pyscf.tools import molden
# Current
molden.from_lasscf(las, 'butadiene.molden')
# If want to plot only active space orbitals, use the arg only_as
molden.from_lasscf(las, 'butadiene.JustactiveSpace.molden', only_as=True)
