### PR TITLE
gpudev update

### DIFF
--- a/debug/lassi/debug_22.py
+++ b/debug/lassi/debug_22.py
@@ -20,7 +20,7 @@ from pyscf import lib, gto, scf, mcscf, ao2mo
 from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
 from mrh.my_pyscf.lassi import LASSI
 from mrh.my_pyscf.lassi.lassi import root_make_rdm12s, make_stdm12s
-from mrh.my_pyscf.lassi.states import all_single_excitations, SingleLASRootspace
+from mrh.my_pyscf.lassi.spaces import all_single_excitations, SingleLASRootspace
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 from mrh.my_pyscf.lassi import op_o0, op_o1, lassis
 

--- a/debug/lassi/debug_c2h4n4.py
+++ b/debug/lassi/debug_c2h4n4.py
@@ -122,7 +122,7 @@ class KnownValues(unittest.TestCase):
     #        self.assertAlmostEqual (e1, e0, 8)
 
     #def test_singles_constructor (self):
-    #    from mrh.my_pyscf.lassi.states import all_single_excitations
+    #    from mrh.my_pyscf.lassi.spaces import all_single_excitations
     #    las2 = all_single_excitations (lsi._las)
     #    las2.check_sanity ()
     #    # Meaning of tuple: (na+nb,smult)
@@ -135,7 +135,7 @@ class KnownValues(unittest.TestCase):
     #    self.assertEqual (las2.nroots, 33)
 
     #def test_spin_shuffle (self):
-    #    from mrh.my_pyscf.lassi.states import spin_shuffle, spin_shuffle_ci
+    #    from mrh.my_pyscf.lassi.spaces import spin_shuffle, spin_shuffle_ci
     #    mf = lsi._las._scf
     #    las3 = spin_shuffle (las)
     #    las3.check_sanity ()

--- a/debug/lassi/debug_lassis_targets_slow.py
+++ b/debug/lassi/debug_lassis_targets_slow.py
@@ -56,8 +56,8 @@ class KnownValues(unittest.TestCase):
     def test_c2h4n4_3frag (self):
         # str
         mol = struct (2.0, 2.0, '6-31g', symmetry=False)
-        mol.output = '/dev/null'
-        mol.verbose = 0
+        mol.output = 'c2h4n4_3frag_str.log'#'/dev/null'
+        mol.verbose = 5#0
         mol.spin = 8
         mol.build ()
         mf = scf.RHF (mol).run () 
@@ -71,8 +71,8 @@ class KnownValues(unittest.TestCase):
         # equil
         mol = struct (0.0, 0.0, '6-31g', symmetry=False)
         mol.spin = 0
-        mol.verbose = 0
-        mol.output = '/dev/null'
+        mol.output = 'c2h4n4_3frag_equil.log'#'/dev/null'
+        mol.verbose = 5#0
         mol.build ()
         mf = scf.RHF (mol).run ()
         las = LASSCF (mf, (4,2,4), ((2,2),(1,1),(2,2)), spin_sub=(1,1,1))
@@ -90,8 +90,8 @@ class KnownValues(unittest.TestCase):
     def test_c2h4n4_2frag (self):
         # str
         mol = struct (2.0, 2.0, '6-31g', symmetry=False)
-        mol.output = '/dev/null'
-        mol.verbose = 0
+        mol.output = 'c2h4n4_2frag_str.log'#'/dev/null'
+        mol.verbose = 5#0
         mol.spin = 8
         mol.build ()
         mf = scf.RHF (mol).run () 
@@ -113,8 +113,8 @@ class KnownValues(unittest.TestCase):
         # equil
         mol = struct (0.0, 0.0, '6-31g', symmetry=False)
         mol.spin = 0
-        mol.verbose = 0
-        mol.output = '/dev/null'
+        mol.output = 'c2h4n4_2frag_equil.log'#'/dev/null'
+        mol.verbose = 5#0
         mol.build ()
         mf = scf.RHF (mol).run ()
         las = lasscf_async.LASSCF (mf, (5,5), ((3,2),(2,3)))
@@ -172,7 +172,8 @@ class KnownValues(unittest.TestCase):
         H      3.367270000000  -0.612150000000  -1.514110000000'''
         basis = {'C': 'sto-3g','H': 'sto-3g','O': 'sto-3g','N': 'sto-3g','Cr': 'cc-pvdz'}
         mol = gto.M (atom=xyz, spin=6, charge=3, basis=basis,
-                   verbose=0, output='/dev/null')
+                     verbose=5, output='kremer.log')
+                     #verbose=0, output='/dev/null')
         mf = scf.ROHF(mol)
         mf.chkfile = 'test_lassis_targets_slow.kremer_cr2_model.chk'
         mf.kernel ()
@@ -227,8 +228,9 @@ class KnownValues(unittest.TestCase):
         C 2.1609242811 -2.1609242811 1.2775841868
         H 2.7960805433 -2.7960805433 1.9182443024'''
         basis = {'C': 'sto-3g','H': 'sto-3g','O': 'sto-3g','Al': 'cc-pvdz','Fe': 'cc-pvdz'}
-        mol = gto.M (atom=xyz, spin=9, charge=0, basis=basis, max_memory=10000, verbose=0,
-                     output='/dev/null')
+        mol = gto.M (atom=xyz, spin=9, charge=0, basis=basis, max_memory=10000,
+                     verbose=5, output='alfefe.log')
+                     #verbose=0, output='/dev/null')
         mf = scf.ROHF(mol)
         mf.init_guess='chk'
         mf.chkfile='test_lassis_targets_slow.alfefe.chk'

--- a/debug/lassi/debug_lassis_timing.py
+++ b/debug/lassi/debug_lassis_timing.py
@@ -60,8 +60,8 @@ def setUpModule ():
     1       -3.206320000     -3.233120000      0.000000000'''
     
     mol = gto.M (atom = xyz, basis='STO-3G', symmetry=False,
-        #verbose=5, output='test_4frag.log')
-        verbose=0, output='/dev/null')
+        verbose=5, output='debug_lassis_timing.log')
+        #verbose=0, output='/dev/null')
     mf = scf.RHF (mol).run ()
     las = LASSCF (mf, (2,2,2,2),((1,1),(1,1),(1,1),(1,1)))
     las.state_average_(weights=weights, **states)
@@ -108,63 +108,49 @@ def tearDownModule():
     del mol, mf, las, nroots, nelec_frs, si
 
 class KnownValues(unittest.TestCase):
-    def test_stdm12s (self):
-        d12_o0 = make_stdm12s (las, opt=0)
-        d12_o1 = make_stdm12s (las, opt=1)
-        for r in range (2):
-            for i, j in product (range (si.shape[0]), repeat=2):
-                with self.subTest (rank=r+1, bra=i, ket=j):
-                    self.assertAlmostEqual (lib.fp (d12_o0[r][i,...,j]),
-                        lib.fp (d12_o1[r][i,...,j]), 9)
+    #def test_stdm12s (self):
+    #    d12_o0 = make_stdm12s (las, opt=0)
+    #    d12_o1 = make_stdm12s (las, opt=1)
+    #    for r in range (2):
+    #        for i, j in product (range (nroots), repeat=2):
+    #            with self.subTest (rank=r+1, bra=i, ket=j):
+    #                self.assertAlmostEqual (lib.fp (d12_o0[r][i,...,j]),
+    #                    lib.fp (d12_o1[r][i,...,j]), 9)
 
-    def test_ham_s2_ovlp (self):
-        h1, h2 = ham_2q (las, las.mo_coeff, veff_c=None, h2eff_sub=None)[1:]
-        lbls = ('ham','s2','ovlp')
-        mats_o0 = op_o0.ham (las, h1, h2, las.ci, nelec_frs)#, orbsym=orbsym, wfnsym=wfnsym)
-        fps_o0 = [lib.fp (mat) for mat in mats_o0]
-        mats_o1 = op_o1.ham (las, h1, h2, las.ci, nelec_frs)#, orbsym=orbsym, wfnsym=wfnsym)
-        for lbl, mat, fp in zip (lbls, mats_o1, fps_o0):
-            with self.subTest(matrix=lbl):
-                self.assertAlmostEqual (lib.fp (mat), fp, 9)
+    #def test_ham_s2_ovlp (self):
+    #    h1, h2 = ham_2q (las, las.mo_coeff, veff_c=None, h2eff_sub=None)[1:]
+    #    lbls = ('ham','s2','ovlp')
+    #    mats_o0 = op_o0.ham (las, h1, h2, las.ci, nelec_frs)#, orbsym=orbsym, wfnsym=wfnsym)
+    #    fps_o0 = [lib.fp (mat) for mat in mats_o0]
+    #    mats_o1 = op_o1.ham (las, h1, h2, las.ci, nelec_frs)#, orbsym=orbsym, wfnsym=wfnsym)
+    #    for lbl, mat, fp in zip (lbls, mats_o1, fps_o0):
+    #        with self.subTest(matrix=lbl):
+    #            self.assertAlmostEqual (lib.fp (mat), fp, 9)
 
-    def test_rdm12s (self):
-        d12_o0 = op_o0.roots_make_rdm12s (las, las.ci, nelec_frs, si)#, orbsym=orbsym, wfnsym=wfnsym)
-        d12_o1 = op_o1.roots_make_rdm12s (las, las.ci, nelec_frs, si)#, orbsym=orbsym, wfnsym=wfnsym)
-        for r in range (2):
-            for i in range (nroots):
-                with self.subTest (rank=r+1, root=i):
-                    self.assertAlmostEqual (lib.fp (d12_o0[r][i]),
-                        lib.fp (d12_o1[r][i]), 9)
-                with self.subTest ('single matrix constructor', opt=0, rank=r+1, root=i):
-                    d12_o0_test = root_make_rdm12s (las, las.ci, si, state=i, soc=False,
-                                                    break_symmetry=False, opt=0)[r]
-                    self.assertAlmostEqual (lib.fp (d12_o0_test), lib.fp (d12_o0[r][i]), 9)
-                with self.subTest ('single matrix constructor', opt=1, rank=r+1, root=i):
-                    d12_o1_test = root_make_rdm12s (las, las.ci, si, state=i, soc=False,
-                                                    break_symmetry=False, opt=1)[r]
-                    self.assertAlmostEqual (lib.fp (d12_o1_test), lib.fp (d12_o0[r][i]), 9)
+    #def test_rdm12s (self):
+    #    d12_o0 = op_o0.roots_make_rdm12s (las, las.ci, nelec_frs, si)#, orbsym=orbsym, wfnsym=wfnsym)
+    #    d12_o1 = op_o1.roots_make_rdm12s (las, las.ci, nelec_frs, si)#, orbsym=orbsym, wfnsym=wfnsym)
+    #    for r in range (2):
+    #        for i in range (nroots):
+    #            with self.subTest (rank=r+1, root=i):
+    #                self.assertAlmostEqual (lib.fp (d12_o0[r][i]),
+    #                    lib.fp (d12_o1[r][i]), 9)
+    #            with self.subTest ('single matrix constructor', opt=0, rank=r+1, root=i):
+    #                d12_o0_test = root_make_rdm12s (las, las.ci, si, state=i, soc=False,
+    #                                                break_symmetry=False, opt=0)[r]
+    #                self.assertAlmostEqual (lib.fp (d12_o0_test), lib.fp (d12_o0[r][i]), 9)
+    #            with self.subTest ('single matrix constructor', opt=1, rank=r+1, root=i):
+    #                d12_o1_test = root_make_rdm12s (las, las.ci, si, state=i, soc=False,
+    #                                                break_symmetry=False, opt=1)[r]
+    #                self.assertAlmostEqual (lib.fp (d12_o1_test), lib.fp (d12_o0[r][i]), 9)
 
-    def test_lassis (self):
-        las0 = las.get_single_state_las (state=0)
-        for ifrag in range (len (las0.ci)):
-            las0.ci[ifrag][0] = las0.ci[ifrag][0][0]
-        lsi = LASSIS (las0)
-        lsi.prepare_states_()
-        self.assertTrue (lsi.converged)
-
-    def test_lassis_1111 (self):
-        xyz='''H 0 0 0
-        H 3 0 0
-        H 6 0 0
-        H 9 0 0'''
-        mol1 = gto.M (atom=xyz, basis='sto3g', symmetry=False, verbose=0, output='/dev/null')
-        mf1 = scf.RHF (mol1).run ()
-
-        las1 = LASSCF (mf1, (1,1,1,1), ((0,1),(1,0),(0,1),(1,0)))
-        mo_coeff = las1.localize_init_guess ([[0,],[1,],[2,],[3,]])
-        las1.lasci_(mo_coeff)
-        lsi = LASSIS (las1).run ()
-        self.assertTrue (lsi.converged)
+    #def test_lassis (self):
+    #    las0 = las.get_single_state_las (state=0)
+    #    for ifrag in range (len (las0.ci)):
+    #        las0.ci[ifrag][0] = las0.ci[ifrag][0][0]
+    #    lsi = LASSIS (las0)
+    #    lsi.prepare_states_()
+    #    self.assertTrue (lsi.converged)
 
     def test_lassis_slow (self):
         las0 = las.get_single_state_las (state=0)
@@ -173,6 +159,7 @@ class KnownValues(unittest.TestCase):
         lsi = LASSIS (las0).run ()
         self.assertTrue (lsi.converged)
         self.assertAlmostEqual (lsi.e_roots[0], -304.5372586630968, 3)
+        root_make_rdm12s (lsi, ci=lsi.ci, si=lsi.si, state=0)
 
 if __name__ == "__main__":
     print("Full Tests for LASSI o1 4-fragment intermediates")

--- a/examples/laspdft/c2h4n4_si_laspdft.py
+++ b/examples/laspdft/c2h4n4_si_laspdft.py
@@ -5,7 +5,7 @@ from mrh.my_pyscf import lassi
 from mrh.my_pyscf import mcpdft
 from mrh.my_pyscf.tools.molden import from_lasscf
 from c2h4n4_struct import structure as struct
-from mrh.my_pyscf.lassi.states import all_single_excitations
+from mrh.my_pyscf.lassi.spaces import all_single_excitations
 
 # Mean field calculation
 mol = struct(0, 0, '6-31g')
@@ -23,7 +23,7 @@ guess_mo = las.sort_mo([16,18,22,23,24,26])
 mo0 = las.localize_init_guess((list(range (5)), list(range (5,10))), guess_mo)
 las.kernel(mo0)
 
-las = lassi.states.all_single_excitations (las)
+las = lassi.spaces.all_single_excitations (las)
 las.lasci ()
 
 lsi = lassi.LASSI(las)

--- a/examples/lasscf_gradients/h2-631g.py
+++ b/examples/lasscf_gradients/h2-631g.py
@@ -1,0 +1,26 @@
+'''
+SV: test file for LASSCF analytical nuclear gradients
+H2 in one full fragment, must be same as CASSCF (2,2)
+'''
+
+from pyscf import gto, scf, lib, geomopt
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
+
+mol = gto.Mole()
+mol.atom = '''H  0 0 0; H 1 1 1'''
+mol.basis = '6-31g'
+mol.build(verbose = 4)
+mol.output = 'h2.log'
+mf = scf.RHF (mol).run ()
+
+las = LASSCF (mf,(2,),(2,), spin_sub=(1))
+
+frag_atom_list = [list (range (2))]
+
+mo_coeff = las.localize_init_guess (frag_atom_list, mf.mo_coeff)
+
+las.kernel (mo_coeff)
+
+# Optimizing geometry using Scanner 
+gs_grad = las.nuc_grad_method().as_scanner()
+mol1 = gs_grad.optimizer().kernel()

--- a/examples/sa_si_lasscf/automatic_singles.py
+++ b/examples/sa_si_lasscf/automatic_singles.py
@@ -44,7 +44,7 @@ e_roots, si_hand = mylassi_hand.kernel()
 print ("LASSI(hand) energy =", e_roots[0])
 molden.from_lassi (las2, 'c2h4n4_las66si4_631g.molden', si=si_hand)
 
-from mrh.my_pyscf.lassi.states import all_single_excitations
+from mrh.my_pyscf.lassi.spaces import all_single_excitations
 las = all_single_excitations (las)
 las.lasci () # Optimize the CI vectors
 las.dump_spaces () # prints all state tables in the output file

--- a/examples/sa_si_lasscf/cr2o3n6h21_lassis66_smallbasis.py
+++ b/examples/sa_si_lasscf/cr2o3n6h21_lassis66_smallbasis.py
@@ -46,12 +46,12 @@ except (OSError, TypeError, KeyError) as e: # First time through you have to mak
     mo_coeff = las.localize_init_guess (([0],[1]), mo_coeff)
 
 # Direct exchange only result
-las = lassi.states.spin_shuffle (las) # generate direct-exchange states
+las = lassi.spaces.spin_shuffle (las) # generate direct-exchange states
 las.weights = [1.0/las.nroots,]*las.nroots # set equal weights
 las.kernel (mo_coeff) # optimize orbitals
 lsi0 = lassi.LASSI (las).run ()
 print (("Direct exchange only is modeled by {} states constructed with "
-        "lassi.states.spin_shuffle").format (las.nroots))
+        "lassi.spaces.spin_shuffle").format (las.nroots))
 print ("J(LASSI, direct) = %.2f cm^-1" % yamaguchi (lsi0.e_roots, lsi0.s2))
 print ("{} rootspaces and {} product states total\n".format (lsi0.nroots, lsi0.si.shape[1]))
 
@@ -70,8 +70,8 @@ print ("{} spin-alpha determinants * {} spin-beta determinants = {} determinants
     mc.ci.shape[0], mc.ci.shape[1], mc.ci.size))
 
 # Direct exchange & kinetic exchange result
-las = lassi.states.all_single_excitations (las) # generate kinetic-exchange states
-print (("Use of lassi.states.all_single_excitations generates "
+las = lassi.spaces.all_single_excitations (las) # generate kinetic-exchange states
+print (("Use of lassi.spaces.all_single_excitations generates "
         "{} additional kinetic-exchange (i.e., charge-transfer) "
         "states").format (las.nroots-4))
 las.lasci () # do not reoptimize orbitals at this step - not likely to converge

--- a/gpu/gpu4pyscf/df/__init__.py
+++ b/gpu/gpu4pyscf/df/__init__.py
@@ -1,18 +1,1 @@
-# gpu4pyscf is a plugin to use Nvidia GPU in PySCF package
-#
-# Copyright (C) 2022 Qiming Sun
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 from . import df_jk

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -157,6 +157,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
 
         t3 = lib.logger.timer(dfobj, 'get_jk with_k setup',*t2)
         for eri1 in dfobj.loop(blksize): # how much time spent unnecessarily copying eri1 data?
+            t6 = (logger.process_clock(), logger.perf_counter())
             naux, nao_pair = eri1.shape
 
             if gpu:
@@ -181,6 +182,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
                     vk[k] += lib.dot(buf1.reshape(-1,nao).T, buf2.reshape(-1,nao))
 
             count+=1
+            lib.logger.timer(dfobj, 'get_jk with_k loop iteration',*t6)
         
         t1 = log.timer_debug1('jk', *t1)
         t4 = lib.logger.timer(dfobj, 'get_jk with_k loop',*t3)

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -67,7 +67,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
             t6 = (logger.process_clock(), logger.perf_counter())
             naux, nao_pair = eri1.shape
             if gpu:
-                if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, 0, count)
+                #if count == 0:
+                libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, 0, count)
                 libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj, vk, 0, count, id(dfobj))
             else:
                 rho = numpy.einsum('ix,px->ip', dmtril, eri1)
@@ -262,7 +263,8 @@ def get_jk_debug(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e
             print("vj= ", vj_tmp.shape)
             print("addr of dfobj= ", hex(id(dfobj)), "  addr of eri1= ", hex(id(eri1)), " count= ", count)
             
-            if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, 0, count)
+            #if count == 0:
+            libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, 0, count)
             libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj_tmp, vk_tmp, 0, count, id(dfobj))
             
             rho = numpy.einsum('ix,px->ip', dmtril, eri1)
@@ -403,8 +405,7 @@ def get_jk_debug(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e
                     vk_err += (vk[i,j,k] - vk_tmp[i,j,k]) * (vk[i,j,k] - vk_tmp[i,j,k])                    
                     #print("ijk= ", i, j, k, "  vk= ", vk[i,j,k], "  vk_tmp= ", vk_tmp[i,j,k], "  vk_err= ", vk_err)
 
-#        stop = False
-        stop = True
+        stop = False
         if(vj_err > 1e-8): stop = True
         if(vk_err > 1e-8): stop = True
         

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -80,6 +80,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
 #        dms = [numpy.asarray(x, order='F') for x in dms]
         count = 0
         for eri1 in dfobj.loop():
+            t6 = (logger.process_clock(), logger.perf_counter())
             naux, nao_pair = eri1.shape
             if gpu:
                 if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, 0, count)
@@ -88,11 +89,13 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
                 rho = numpy.einsum('ix,px->ip', dmtril, eri1)
                 vj += numpy.einsum('ip,px->ix', rho, eri1)
 
+            lib.logger.timer(dfobj, 'get_jk not with_k loop iteration',*t6)
+
             count += 1
 
         if gpu:
             libgpu.libgpu_pull_get_jk(gpu, vj, vk, 0)
-        t3 = lib.logger.timer(dfobj, 'get_jk not with_k',*t2)
+        t3 = lib.logger.timer(dfobj, 'get_jk not with_k loop full',*t2)
 
 # Commented 2-19-2024 in favor of accelerated implementation below
 # Can offload this if need arises.
@@ -156,36 +159,62 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
         vj = numpy.zeros_like(dmtril)
 
         t3 = lib.logger.timer(dfobj, 'get_jk with_k setup',*t2)
-        for eri1 in dfobj.loop(blksize): # how much time spent unnecessarily copying eri1 data?
-            t6 = (logger.process_clock(), logger.perf_counter())
-            naux, nao_pair = eri1.shape
 
-            if gpu:
+        load_eri = True
+
+        if gpu:
+            arg = numpy.array([-1, -1, -1, -1], dtype=numpy.int32)
+            libgpu.libgpu_get_dfobj_status(gpu, id(dfobj), arg)
+            if arg[2] > -1: load_eri = False
+
+        if load_eri:
+        
+            for eri1 in dfobj.loop(blksize): # how much time spent unnecessarily copying eri1 data?
+                t6 = (logger.process_clock(), logger.perf_counter())
+                naux, nao_pair = eri1.shape
+
+                if gpu:
+                    if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
+                    libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj, vk, 1, count, id(dfobj))
+                
+                else:
+                
+                    if with_j:
+                        rho = numpy.einsum('ix,px->ip', dmtril, eri1)
+                        vj += numpy.einsum('ip,px->ix', rho, eri1)
+                    
+                    for k in range(nset):
+                        buf1 = buf[0,:naux]
+                        fdrv(ftrans, fmmm,
+                             buf1.ctypes.data_as(ctypes.c_void_p),
+                             eri1.ctypes.data_as(ctypes.c_void_p),
+                             dms[k].ctypes.data_as(ctypes.c_void_p),
+                             ctypes.c_int(naux), *rargs)
+                        
+                        buf2 = lib.unpack_tril(eri1, out=buf[1])
+                        vk[k] += lib.dot(buf1.reshape(-1,nao).T, buf2.reshape(-1,nao))
+
+                count+=1
+                lib.logger.timer(dfobj, 'get_jk with_k loop iteration',*t6)
+
+        else:
+            
+            nblk = arg[2]
+            for count in range( arg[2] ):
+                t6 = (logger.process_clock(), logger.perf_counter())
+                arg = numpy.array([-1, -1, count, -1], dtype=numpy.int32)
+                libgpu.libgpu_get_dfobj_status(gpu, id(dfobj), arg)
+                naux = arg[0]
+                nao_pair = arg[1]
+
+                eri1 = numpy.zeros(1)
                 if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
                 libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj, vk, 1, count, id(dfobj))
-
-            else:
                 
-                if with_j:
-                    rho = numpy.einsum('ix,px->ip', dmtril, eri1)
-                    vj += numpy.einsum('ip,px->ix', rho, eri1)
+                lib.logger.timer(dfobj, 'get_jk with_k loop iteration',*t6)
                 
-                for k in range(nset):
-                    buf1 = buf[0,:naux]
-                    fdrv(ftrans, fmmm,
-                         buf1.ctypes.data_as(ctypes.c_void_p),
-                         eri1.ctypes.data_as(ctypes.c_void_p),
-                         dms[k].ctypes.data_as(ctypes.c_void_p),
-                         ctypes.c_int(naux), *rargs)
-                    
-                    buf2 = lib.unpack_tril(eri1, out=buf[1])
-                    vk[k] += lib.dot(buf1.reshape(-1,nao).T, buf2.reshape(-1,nao))
-
-            count+=1
-            lib.logger.timer(dfobj, 'get_jk with_k loop iteration',*t6)
-        
+        t4 = lib.logger.timer(dfobj, 'get_jk with_k loop full',*t3)
         t1 = log.timer_debug1('jk', *t1)
-        t4 = lib.logger.timer(dfobj, 'get_jk with_k loop',*t3)
 
         if gpu:
             libgpu.libgpu_pull_get_jk(gpu, vj, vk, 1)

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -175,7 +175,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
                 naux, nao_pair = eri1.shape
 
                 if gpu:
-                    if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
+                    #if count == 0:
+                    libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
                     libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj, vk, 1, count, id(dfobj))
                 
                 else:
@@ -376,7 +377,8 @@ def get_jk_debug(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e
             print("vj= ", vj_tmp.shape, " vk= ", vk_tmp.shape)
             print("addr of dfobj= ", hex(id(dfobj)), "  addr of eri1= ", hex(id(eri1)), " count= ", count)
             #if gpu:
-            if count == 0: libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
+            #if count == 0:
+            libgpu.libgpu_init_get_jk(gpu, eri1, dmtril, blksize, nset, nao, naux, count)
             libgpu.libgpu_compute_get_jk(gpu, naux, eri1, dmtril, dms, vj_tmp, vk_tmp, 1, count, id(dfobj))
             if count == -1: quit()
 

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -187,6 +187,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
 
         if gpu:
             libgpu.libgpu_pull_get_jk(gpu, vj, vk, 1)
+        t5 = lib.logger.timer(dfobj, 'get_jk with_k pull',*t4)
         
     t2 = (logger.process_clock(), logger.perf_counter())
     if with_j: vj = lib.unpack_tril(vj, 1).reshape(dm_shape)

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Author: Qiming Sun <osirpt.sun@gmail.com>
-#
 
 import copy
 
@@ -419,7 +403,8 @@ def get_jk_debug(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e
                     vk_err += (vk[i,j,k] - vk_tmp[i,j,k]) * (vk[i,j,k] - vk_tmp[i,j,k])                    
                     #print("ijk= ", i, j, k, "  vk= ", vk[i,j,k], "  vk_tmp= ", vk_tmp[i,j,k], "  vk_err= ", vk_err)
 
-        stop = False
+#        stop = False
+        stop = True
         if(vj_err > 1e-8): stop = True
         if(vk_err > 1e-8): stop = True
         

--- a/gpu/gpu4pyscf/df/df_jk.py
+++ b/gpu/gpu4pyscf/df/df_jk.py
@@ -162,10 +162,11 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
 
         load_eri = True
 
-        if gpu:
-            arg = numpy.array([-1, -1, -1, -1], dtype=numpy.int32)
-            libgpu.libgpu_get_dfobj_status(gpu, id(dfobj), arg)
-            if arg[2] > -1: load_eri = False
+        # load_eri = False doesn't offer benefit unless deep-copies and so on. disable for now
+#        if gpu:
+#            arg = numpy.array([-1, -1, -1, -1], dtype=numpy.int32)
+#            libgpu.libgpu_get_dfobj_status(gpu, id(dfobj), arg)
+#            if arg[2] > -1: load_eri = False
 
         if load_eri:
         

--- a/gpu/gpu4pyscf/df/patch_pyscf.py
+++ b/gpu/gpu4pyscf/df/patch_pyscf.py
@@ -1,24 +1,3 @@
-# gpu4pyscf is a plugin to use Nvidia GPU in PySCF package
-#
-# Copyright (C) 2022 Qiming Sun
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-'''
-Patch pyscf SCF modules to make all subclass of SCF class support GPU mode.
-'''
-
 from gpu4pyscf.df.df_jk import _get_jk
 from pyscf.df import df_jk
 

--- a/gpu/gpu4pyscf/gto/__init__.py
+++ b/gpu/gpu4pyscf/gto/__init__.py
@@ -1,18 +1,1 @@
-# gpu4pyscf is a plugin to use Nvidia GPU in PySCF package
-#
-# Copyright (C) 2022 Qiming Sun
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 from . import mole

--- a/gpu/gpu4pyscf/gto/mole.py
+++ b/gpu/gpu4pyscf/gto/mole.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python
-# Copyright 2014-2021 The PySCF Developers. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Author: Qiming Sun <osirpt.sun@gmail.com>
-#
 
 from pyscf.gto.mole import *
 

--- a/gpu/gpu4pyscf/gto/patch_pyscf.py
+++ b/gpu/gpu4pyscf/gto/patch_pyscf.py
@@ -1,20 +1,3 @@
-# gpu4pyscf is a plugin to use Nvidia GPU in PySCF package
-#
-# Copyright (C) 2022 Qiming Sun
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 from gpu4pyscf import gto as mrh_gto
 from pyscf import gto
 from gpu4pyscf.lib.utils import patch_cpu_kernel

--- a/gpu/mini-apps/transpose/Makefile
+++ b/gpu/mini-apps/transpose/Makefile
@@ -1,0 +1,89 @@
+#
+# Definition of MACROS
+
+BINROOT=./
+EXE=libgpu.so
+SHELL=/bin/sh
+CXX = g++
+CXXFLAGS=
+FC=gfortran
+FCFLAGS=
+LD = g++
+LDFLAGS = -fPIC -shared
+AR = ar rcs
+CPP=cpp -P -traditional
+INSTALL=../
+
+ARCH ?= polaris
+include ../../src/arch/$(ARCH)
+
+CXXFLAGS += -I../../src
+
+$(info ARCH is [${ARCH}])
+
+CSRC = $(wildcard *.cpp)
+INC = $(wildcard *.h)
+COBJ = $(CSRC:.cpp=.o)
+
+FSRC = $(wildcard *.F90)
+MOD = $(FSRC:.F90=.mod)
+FOBJ = $(FSRC:.F90=.o)
+
+#$(info CSRC is [${CSRC}])
+#$(info INC is [${INC}])
+#$(info COBJ is [${COBJ}])
+
+#$(info FSRC is [${FSRC}])
+#$(info MOD is [${MOD}])
+#$(info FOBJ is [${FOBJ}])
+
+
+#
+# -- target : 	Dependencies
+# --		Rule to create target
+
+$(EXE):	$(COBJ) $(FOBJ) $(MOD)
+	$(LD) $(LDFLAGS) -o $@ $(COBJ) $(LIB)
+
+install: $(EXE)
+	cp $(EXE) $(INSTALL)
+#	cp $(MOD) $(FOBJ) $(INSTALL)/include
+
+####################################################################
+
+$(COBJ): %.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $<
+
+$(FOBJ): %.o: %.F90
+	$(FC) $(FCFLAGS) -c $<
+
+$(MOD): %.mod: %.F90
+	$(FC) $(FCFLAGS) -c $<
+
+#
+# -- Remove *.o and *~ from the directory
+clean:
+	rm -f *.o *.mod *~ $(EXE)
+	rm -f $(INSTALL)/$(EXE)
+	rm -rf $(EXE).dSYM
+#
+# -- Remove *.o, *~, and executable from the directory
+realclean:
+	rm -f *.o *.mod *~ $(EXE)
+	rm -f $(INSTALL)/$(EXE)
+	rm -rf $(EXE).dSYM
+	rm -f *.optrpt
+
+#
+# -- Simple dependencies
+
+libgpu.o : libgpu.cpp libgpu.h
+
+pm_cuda.o : pm_cuda.cpp pm_cuda.h pm.h
+pm_host.o : pm_host.cpp pm_host.h pm.h
+pm_openmp.o : pm_openmp.cpp pm_openmp.h pm.h
+
+device_cuda.o : device_cuda.cpp device.h
+device_host.o : device_host.cpp device.h
+device_openmp.o : device_openmp.cpp device.h
+device.o : device.cpp device.h

--- a/gpu/mini-apps/transpose/main.cpp
+++ b/gpu/mini-apps/transpose/main.cpp
@@ -1,0 +1,389 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <iostream>
+#include <cassert>
+
+#include <mpi.h>
+#include <omp.h>
+
+#include "pm.h"
+
+// polymer_async : 6-31g
+// -- nfrags = 16 :: nrow= 85,440  ncol= 356 copy_naive= 426 GB/s  transpose_naive= 151 GB/s  transpose_gpu= 383 GB/s  transpose_gpu_2= 538 GB/s
+// --                nrow= 50,552  ncol= 356 copy_naive= 390 GB/s  transpose_naive= 126 GB/s  transpose_gpu= 273 GB/s  transpose_gpu_2= 396 GB/s
+// --                nrow= 10,560  ncol=  44 copy_naive= 198 GB/s  transpose_naive= 158 GB/s  transpose_gpu= 200 GB/s  transpose_gpu_2= 263 GB/s
+// --                nrow=  6,248  ncol=  44 copy_naive= 148 GB/s  transpose_naive= 132 GB/s  transpose_gpu= 191 GB/s  transpose_gpu_2= 249 GB/s
+
+// fefefe_15_16
+// --   naux=240, nao=708   nrow= 169,920 ncol= 708
+// --                                        copy_naive= 449 GB/s  transpose_naive= 153 GB/s  transpose_gpu= 385 GB/s  transpose_gpu_2= 525 GB/s
+// --   naux=169, nao=708   nrow= 119,652 ncol= 708
+// --                                        copy_naive= 442 GB/s  transpose_naive= 159 GB/s  transpose_gpu= 501 GB/s  transpose_gpu_2= 533 GB/
+
+#define _NUM_ROWS 50552
+#define _NUM_COLS 356
+
+#define _TRANSPOSE_BLOCK_SIZE 16
+#define _TRANSPOSE_NUM_ROWS 16
+
+#define _TOL 1e-8
+#define _NUM_ITERATIONS_CPU 20
+#define _NUM_ITERATIONS_GPU 10
+
+#define _TILE(A,B) (A + B - 1) / B
+
+#ifdef _SINGLE_PRECISION
+  typedef float real_t;
+#else
+  typedef double real_t;
+#endif
+
+using namespace PM_NS;
+
+// ----------------------------------------------------------------
+
+//https://github.com/NVIDIA-developer-blog/code-samples/blob/master/series/cuda-cpp/transpose/transpose.cu
+// modified to support nonsquare matrices
+
+__global__ void _transpose_gpu(double * out, double * in, int nrow, int ncol)
+{
+  __shared__ double cache[_TRANSPOSE_BLOCK_SIZE][_TRANSPOSE_BLOCK_SIZE];
+  
+  int irow = blockIdx.x * _TRANSPOSE_BLOCK_SIZE + threadIdx.x;
+  int icol = blockIdx.y * _TRANSPOSE_BLOCK_SIZE + threadIdx.y;
+
+  // load tile into fast local memory
+
+  const int indxi = irow * ncol + icol;
+  for(int i=0; i<_TRANSPOSE_BLOCK_SIZE; i+= _TRANSPOSE_NUM_ROWS) {
+    if(irow < nrow && (icol+i) < ncol) // nonsquare
+      cache[threadIdx.y + i][threadIdx.x] = in[indxi + i]; // threads read chunk of a row and write as a column
+  }
+
+  // block to ensure reads finish
+  
+  __syncthreads();
+
+  // swap indices
+  
+  irow = blockIdx.y * _TRANSPOSE_BLOCK_SIZE + threadIdx.x;
+  icol = blockIdx.x * _TRANSPOSE_BLOCK_SIZE + threadIdx.y;
+
+  // write tile to global memory
+
+  const int indxo = irow * nrow + icol;
+  for(int i=0; i<_TRANSPOSE_BLOCK_SIZE; i+= _TRANSPOSE_NUM_ROWS) {
+    if(irow < ncol && (icol + i) < nrow) // nonsquare
+      out[indxo + i] = cache[threadIdx.x][threadIdx.y + i];
+  }
+}
+
+// ----------------------------------------------------------------
+
+__global__ void _transpose_gpu_2(double * out, double * in, int nrow, int ncol)
+{
+  __shared__ double cache[_TRANSPOSE_BLOCK_SIZE][_TRANSPOSE_BLOCK_SIZE+1];
+  
+  int irow = blockIdx.x * _TRANSPOSE_BLOCK_SIZE + threadIdx.x;
+  int icol = blockIdx.y * _TRANSPOSE_BLOCK_SIZE + threadIdx.y;
+
+  // load tile into fast local memory
+
+  const int indxi = irow * ncol + icol;
+  for(int i=0; i<_TRANSPOSE_BLOCK_SIZE; i+= _TRANSPOSE_NUM_ROWS) {
+    if(irow < nrow && (icol+i) < ncol) // nonsquare
+      cache[threadIdx.y + i][threadIdx.x] = in[indxi + i]; // threads read chunk of a row and write as a column
+  }
+
+  // block to ensure reads finish
+  
+  __syncthreads();
+
+  // swap indices
+  
+  irow = blockIdx.y * _TRANSPOSE_BLOCK_SIZE + threadIdx.x;
+  icol = blockIdx.x * _TRANSPOSE_BLOCK_SIZE + threadIdx.y;
+
+  // write tile to global memory
+
+  const int indxo = irow * nrow + icol;
+  for(int i=0; i<_TRANSPOSE_BLOCK_SIZE; i+= _TRANSPOSE_NUM_ROWS) {
+    if(irow < ncol && (icol + i) < nrow) // nonsquare
+      out[indxo + i] = cache[threadIdx.x][threadIdx.y + i];
+  }
+}
+
+// ----------------------------------------------------------------
+
+__global__ void _transpose_naive_gpu(double * out, double * in, int nrow, int ncol)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if(i >= nrow) return;
+
+  int j = blockIdx.y * blockDim.y + threadIdx.y;
+  
+  while (j < ncol) {
+    out[j*nrow + i] = in[i*ncol + j];
+    j += blockDim.y;
+  }
+  
+}
+
+// ----------------------------------------------------------------
+
+__global__ void _copy_naive_gpu(double * out, double * in, int nrow, int ncol)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if(i >= nrow) return;
+
+  int j = blockIdx.y * blockDim.y + threadIdx.y;
+  
+  while (j < ncol) {
+    out[i*ncol + j] = in[i*ncol + j];
+    j += blockDim.y;
+  }
+  
+}
+
+// ----------------------------------------------------------------
+
+void _transpose_naive_cpu(real_t * out, real_t * in, int num_rows, int num_cols)
+{
+  for(int i=0; i<num_rows; ++i)
+    for(int j=0; j<num_cols; ++j)
+      out[j*num_rows + i] = in[i*num_cols + j];
+}
+
+
+// ----------------------------------------------------------------
+
+int check_result(real_t * ref, real_t * test, int n, const char * name)
+{
+  int err = 0;
+  for(int i=0; i<n; ++i) {
+    real_t diff = (ref[i] - test[i]) * (ref[i] - test[i]);
+    if(diff > _TOL) err++;
+  }
+  
+  if(err == 0) printf("Results from %s are correct!! :) \n", name);
+  else printf("Results from %s are incorrect!! :( \n", name);
+  
+  return err;
+}
+
+// ----------------------------------------------------------------
+
+void print_matrix(real_t * data, int num_rows, int num_cols, const char * name)
+{
+  printf("\nMatrix[%s] : %i x %i \n",name, num_rows, num_cols);
+  for(int i=0; i<num_rows; ++i) {
+    for(int j=0; j<num_cols; ++j) printf(" %f", data[i*num_cols + j]);
+    printf("\n");
+  }
+}
+
+// ----------------------------------------------------------------
+
+void print_summary(real_t t, int num_rows, int num_cols, int num_iter, const char * name)
+{
+  double time = t * 1000.0; // ms
+  double size = num_rows * num_cols * sizeof(real_t) / 1024.0 / 1024.0 / 1024.0; // GB
+
+  double bandwidth = size * num_iter / t;
+  
+  printf("\nMatrix[%s] : %i x %i  num_iter= %i  size= %f  [MB]  time= %f  [ms]  bandwidth= %f  [GB/s]\n",
+	 name, num_rows, num_cols, num_iter, size, time, bandwidth);
+}
+
+// ----------------------------------------------------------------
+						 
+int main( int argc, char* argv[] )
+{
+  MPI_Init(&argc, &argv);
+
+  int me,nranks;
+  MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+  MPI_Comm_rank(MPI_COMM_WORLD, &me);
+
+#ifdef _SINGLE_PRECISION
+  if(me == 0) printf("Using single-precision\n\n");
+#else
+  if(me == 0) printf("Using double-precision\n\n");
+#endif
+  
+  real_t * a = (real_t*) malloc(_NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  real_t * b = (real_t*) malloc(_NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  real_t * r = (real_t*) malloc(_NUM_ROWS * _NUM_COLS * sizeof(real_t));
+
+  // Initialize host
+  
+  for(int i=0; i<_NUM_ROWS; ++i) {
+    for(int j=0; j<_NUM_COLS; ++j) {
+      a[i*_NUM_COLS + j] = i * _NUM_COLS + j;
+      r[j*_NUM_ROWS + i] = i * _NUM_COLS + j; // transposed reference
+    }
+  }
+
+  // ----------------------------------------------------------------
+  
+  _transpose_naive_cpu(b, a, _NUM_ROWS, _NUM_COLS);
+  double t0 = MPI_Wtime();
+  for(int i=0; i<_NUM_ITERATIONS_CPU; ++i)
+    _transpose_naive_cpu(b, a, _NUM_ROWS, _NUM_COLS);
+  double t = MPI_Wtime() - t0;
+
+  print_summary(t, _NUM_ROWS, _NUM_COLS, _NUM_ITERATIONS_CPU, "transpose_naive_cpu");
+
+  check_result(r, b, _NUM_ROWS*_NUM_COLS, "naive_cpu");
+  
+  //  print_matrix(a, _NUM_ROWS, _NUM_COLS, "Original a");
+
+  //  print_matrix(b, _NUM_COLS, _NUM_ROWS, "Transposed b");
+
+  //  print_matrix(r, _NUM_COLS, _NUM_ROWS, "Reference r");
+
+  // ----------------------------------------------------------------
+
+  class PM * pm = new PM();
+  
+  int num_devices = pm->dev_num_devices();
+
+  if(me == 0) {
+    printf("# of devices= %i\n",num_devices);
+    pm->dev_properties(num_devices);
+  }
+
+  // Device ID
+
+  int device_id = me % num_devices;
+  for(int i=0; i<nranks; ++i) {
+    if(i == me) {
+      printf("Rank %i running on GPU %i!\n",me,device_id);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+
+  // Create device buffers and transfer data to device
+
+  real_t * d_a = (real_t *) pm->dev_malloc(_NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  real_t * d_b = (real_t *) pm->dev_malloc(_NUM_ROWS * _NUM_COLS * sizeof(real_t));
+
+  for(int i=0; i<_NUM_ROWS*_NUM_COLS; ++i) b[i] = -1.0;
+  
+  pm->dev_push(d_a, a, _NUM_ROWS * _NUM_COLS * sizeof(real_t));
+
+  // ----------------------------------------------------------------
+  
+  // Execute kernel
+
+  {
+    dim3 grid_size(_NUM_ROWS, 1, 1);
+    dim3 block_size(1, _TRANSPOSE_BLOCK_SIZE, 1);
+
+    _copy_naive_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    t0 = MPI_Wtime();
+    for(int i=0; i<_NUM_ITERATIONS_GPU; ++i)
+      _copy_naive_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    cudaDeviceSynchronize();
+    t = MPI_Wtime() - t0;
+  }
+  
+  print_summary(t, _NUM_ROWS, _NUM_COLS, _NUM_ITERATIONS_GPU, "_copy_naive_gpu");
+
+  // ----------------------------------------------------------------
+  
+  // Execute kernel
+
+  {
+    dim3 grid_size(_NUM_ROWS, 1, 1);
+    dim3 block_size(1, _TRANSPOSE_BLOCK_SIZE, 1);
+
+    _transpose_naive_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    t0 = MPI_Wtime();
+    for(int i=0; i<_NUM_ITERATIONS_GPU; ++i)
+      _transpose_naive_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    cudaDeviceSynchronize();
+    t = MPI_Wtime() - t0;
+  }
+  
+  // Transfer data from device
+
+  pm->dev_pull(d_b, b, _NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  
+  check_result(r, b, _NUM_ROWS*_NUM_COLS, "transpose_naive_gpu");
+
+  print_summary(t, _NUM_ROWS, _NUM_COLS, _NUM_ITERATIONS_GPU, "_transpose_naive_gpu");
+
+  //print_matrix(b, _NUM_COLS, _NUM_ROWS, "Transposed b from naive_gpu");
+
+  // ----------------------------------------------------------------
+  
+  // Execute kernel
+
+  {
+    dim3 grid_size(_TILE(_NUM_ROWS, _TRANSPOSE_BLOCK_SIZE), _TILE(_NUM_COLS, _TRANSPOSE_BLOCK_SIZE), 1);
+    dim3 block_size(_TRANSPOSE_BLOCK_SIZE, _TRANSPOSE_NUM_ROWS, 1);
+
+    printf("\ngrid_size= %i %i %i\n", _TILE(_NUM_ROWS, _TRANSPOSE_BLOCK_SIZE), _TILE(_NUM_COLS, _TRANSPOSE_BLOCK_SIZE), 1);
+    printf("block_size= %i %i %i\n",_TRANSPOSE_BLOCK_SIZE, _TRANSPOSE_NUM_ROWS, 1);
+    
+    _transpose_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    t0 = MPI_Wtime();
+    for(int i=0; i<_NUM_ITERATIONS_GPU; ++i)
+      _transpose_gpu<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    cudaDeviceSynchronize();
+    t = MPI_Wtime() - t0;
+  }
+  
+  // Transfer data from device
+
+  pm->dev_pull(d_b, b, _NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  
+  check_result(r, b, _NUM_ROWS*_NUM_COLS, "transpose_gpu");
+
+  print_summary(t, _NUM_ROWS, _NUM_COLS, _NUM_ITERATIONS_GPU, "_transpose_gpu");
+
+  //  print_matrix(b, _NUM_COLS, _NUM_ROWS, "Transposed b from transpose_gpu");
+  
+  // ----------------------------------------------------------------
+  
+  // Execute kernel
+
+  {
+    dim3 grid_size(_TILE(_NUM_ROWS, _TRANSPOSE_BLOCK_SIZE), _TILE(_NUM_COLS, _TRANSPOSE_BLOCK_SIZE), 1);
+    dim3 block_size(_TRANSPOSE_BLOCK_SIZE, _TRANSPOSE_NUM_ROWS, 1);
+    
+    _transpose_gpu_2<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    t0 = MPI_Wtime();
+    for(int i=0; i<_NUM_ITERATIONS_GPU; ++i)
+      _transpose_gpu_2<<<grid_size, block_size>>>(d_b, d_a, _NUM_ROWS, _NUM_COLS);
+    cudaDeviceSynchronize();
+    t = MPI_Wtime() - t0;
+  }
+  
+  // Transfer data from device
+
+  pm->dev_pull(d_b, b, _NUM_ROWS * _NUM_COLS * sizeof(real_t));
+  
+  check_result(r, b, _NUM_ROWS*_NUM_COLS, "transpose_gpu_2");
+
+  print_summary(t, _NUM_ROWS, _NUM_COLS, _NUM_ITERATIONS_GPU, "_transpose_gpu_2");
+
+  //  print_matrix(b, _NUM_COLS, _NUM_ROWS, "Transposed b from transpose_gpu_2");
+  
+  // Clean up
+
+  pm->dev_free(d_a);
+  pm->dev_free(d_b);
+  
+  delete pm;
+    
+  free(a);
+  free(b);
+  free(r);
+
+  MPI_Finalize();
+}

--- a/gpu/src/Makefile
+++ b/gpu/src/Makefile
@@ -17,6 +17,10 @@ INSTALL=../
 ARCH ?= polaris
 include arch/$(ARCH)
 
+# couple more flags to build shared library (allows arch files to be used for general app building)
+CUDA_CXXFLAGS += -shared -Xcompiler -fPIC
+LDFLAGS += -fPIC -shared
+
 $(info ARCH is [${ARCH}])
 
 CSRC = $(wildcard *.cpp)
@@ -34,7 +38,6 @@ FOBJ = $(FSRC:.F90=.o)
 #$(info FSRC is [${FSRC}])
 #$(info MOD is [${MOD}])
 #$(info FOBJ is [${FOBJ}])
-
 
 #
 # -- target : 	Dependencies

--- a/gpu/src/Makefile.nvcc
+++ b/gpu/src/Makefile.nvcc
@@ -20,6 +20,10 @@ CUDA_CXXFLAGS =
 ARCH ?= polaris-gnu
 include arch/$(ARCH)
 
+# couple more flags to build shared library (allows arch files to be used for general app building)
+CUDA_CXXFLAGS += -shared -Xcompiler -fPIC
+LDFLAGS += -fPIC -shared
+
 # -- subset of src files with cuda kernels
 CUDA_SRC = pm_cuda.cpp device_cuda.cpp
 CUDA_OBJ = $(CUDA_SRC:.cpp=.o)

--- a/gpu/src/arch/mac
+++ b/gpu/src/arch/mac
@@ -21,7 +21,8 @@ CXXFLAGS += -D_USE_CPU
 #CXXFLAGS += -I$(BLAS)/include
 
 LD = $(CXX)
-LDFLAGS = -fopenmp -fPIC -undefined dynamic_lookup -shared
+LDFLAGS = -fopenmp 
+#LDFLAGS += -fPIC -undefined dynamic_lookup -shared
 LIB =
 #LIB += -L$(BLAS)/lib -lrefblas 
 LIB += -lstdc++

--- a/gpu/src/arch/midway
+++ b/gpu/src/arch/midway
@@ -17,14 +17,15 @@ CXXFLAGS += -D_CUDA_NVTX
 CUDA_CXXFLAGS = $(PYTHON_INC)
 CUDA_CXXFLAGS += -arch=sm_37
 CUDA_CXXFLAGS += -Xcompiler -fopenmp
-CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
+#CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
 CUDA_CXXFLAGS += -D_USE_GPU -D_GPU_CUDA
 CUDA_CXXFLAGS += -I$(CUDA_HOME)/include
 #CUDA_CXXFLAGS += -D_SIMPLE_TIMER
 CUDA_CXXFLAGS += -D_CUDA_NVTX
 
 LD = $(CXX)
-LDFLAGS = -fopenmp -fPIC -shared
+LDFLAGS = -fopenmp 
+#LDFLAGS += -fPIC -shared
 
 LIB = -lstdc++
 LIB += $(CUDA_HOME)/lib64/libcudart_static.a

--- a/gpu/src/arch/polaris
+++ b/gpu/src/arch/polaris
@@ -14,7 +14,8 @@ CXXFLAGS += -D_SIMPLE_TIMER
 CXXFLAGS += -D_CUDA_NVTX
 
 LD = $(CXX)
-LDFLAGS = -mp -cuda -fPIC -shared
+LDFLAGS = -mp -cuda
+#LDFLAGS += -fPIC -shared
 LIB = -lstdc++
 LIB += -L/soft/compilers/cudatoolkit/cuda-11.4.4/lib64 -lcublas
 LIB += -lnvToolsExt

--- a/gpu/src/arch/polaris-cpu
+++ b/gpu/src/arch/polaris-cpu
@@ -15,5 +15,6 @@ CXXFLAGS += -D_USE_CPU
 
 LD = $(FC)
 #LDFLAGS = -mp -fPIC -undefined dynamic_lookup -shared
-LDFLAGS = -mp -fPIC -shared
+LDFLAGS = -mp
+#LDFLAGS += -fPIC -shared
 LIB = -lstdc++

--- a/gpu/src/arch/polaris-cpu-gnu
+++ b/gpu/src/arch/polaris-cpu-gnu
@@ -15,6 +15,7 @@ CXXFLAGS += -D_USE_CPU
 CXXFLAGS += -D_SIMPLE_TIMER
 
 LD = $(FC)
-LDFLAGS = -fopenmp -fPIC -shared
+LDFLAGS = -fopenmp
+#LDFLAGS += -fPIC -shared
 LIB = -lstdc++
 LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran

--- a/gpu/src/arch/polaris-cpu-nvhpc
+++ b/gpu/src/arch/polaris-cpu-nvhpc
@@ -22,7 +22,8 @@ CXXFLAGS += -D_USE_CPU
 CXXFLAGS += -D_SIMPLE_TIMER
 
 LD = $(FC)
-LDFLAGS = -fopenmp -fPIC -shared
+LDFLAGS = -fopenmp 
+#LDFLAGS += -fPIC -shared
 LIB = -lstdc++
 LIB += -L$(PATH_TO_NVHPC)/compilers/lib64 -llapack -lblas
 #LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran

--- a/gpu/src/arch/polaris-gnu-nvcc
+++ b/gpu/src/arch/polaris-gnu-nvcc
@@ -2,16 +2,20 @@ INSTALL = ../../my_pyscf/gpu
 
 PYTHON_INC=$(shell python -m pybind11 --includes)
 
+PATH_TO_NVCC = $(shell which nvcc)
+PATH_TO_CUDA = $(shell echo ${PATH_TO_NVCC} | rev | cut -d '/' -f 3- | rev)
+$(info PATH_TO_CUDA= [${PATH_TO_CUDA}])
+
 FC = ftn
 FCFLAGS = -g -fopenmp -O3
 
 CXX = CC
 CXXFLAGS = -g -fPIC -fopenmp -O3
-CXXFLAGS += -I$(NVIDIA_PATH)/cuda/include
+CXXFLAGS += -I$(PATH_TO_CUDA)/include
 CXXFLAGS += $(PYTHON_INC)
 
 CXXFLAGS += -D_USE_GPU -D_GPU_CUDA
-CXXFLAGS += -I/soft/compilers/cudatoolkit/cuda-11.4.4/include
+CXXFLAGS += -I$(PATH_TO_CUDA)/include
 #CXXFLAGS += -D_SIMPLE_TIMER
 CXXFLAGS += -D_CUDA_NVTX
 
@@ -19,7 +23,7 @@ CUDA_CXXFLAGS = $(PYTHON_INC)
 CUDA_CXXFLAGS += -Xcompiler -fopenmp
 #CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
 CUDA_CXXFLAGS += -D_USE_GPU -D_GPU_CUDA
-CUDA_CXXFLAGS += -I/soft/compilers/cudatoolkit/cuda-11.4.4/include
+CUDA_CXXFLAGS += -I$(PATH_TO_CUDA)/include
 #CUDA_CXXFLAGS += -D_SIMPLE_TIMER
 CUDA_CXXFLAGS += -D_CUDA_NVTX
 
@@ -29,5 +33,5 @@ LDFLAGS += -fPIC -shared
 
 LIB = -lstdc++
 LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran
-LIB += -L/soft/compilers/cudatoolkit/cuda-11.4.4/lib64 -lcublas
+LIB += -L$(PATH_TO_CUDA)/lib64 -lcublas -lcudart
 LIB += -lnvToolsExt

--- a/gpu/src/arch/polaris-gnu-nvcc
+++ b/gpu/src/arch/polaris-gnu-nvcc
@@ -7,9 +7,11 @@ PATH_TO_CUDA = $(shell echo ${PATH_TO_NVCC} | rev | cut -d '/' -f 3- | rev)
 $(info PATH_TO_CUDA= [${PATH_TO_CUDA}])
 
 FC = ftn
+#FC = gfortran 
 FCFLAGS = -g -fopenmp -O3
 
 CXX = CC
+#CXX = g++
 CXXFLAGS = -g -fPIC -fopenmp -O3
 CXXFLAGS += -I$(PATH_TO_CUDA)/include
 CXXFLAGS += $(PYTHON_INC)
@@ -20,6 +22,8 @@ CXXFLAGS += -I$(PATH_TO_CUDA)/include
 CXXFLAGS += -D_CUDA_NVTX
 
 CUDA_CXXFLAGS = $(PYTHON_INC)
+#CUDA_CXXFLAGS += --dryrun
+CUDA_CXXFLAGS += -ccbin=CC
 CUDA_CXXFLAGS += -Xcompiler -fopenmp
 #CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
 CUDA_CXXFLAGS += -D_USE_GPU -D_GPU_CUDA
@@ -32,6 +36,7 @@ LDFLAGS = -fopenmp
 LDFLAGS += -fPIC -shared
 
 LIB = -lstdc++
-LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran
+#LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran
+LIB += /grand/LASSCF_gpudev/knight/soft/openblas/lib/libopenblas.so
 LIB += -L$(PATH_TO_CUDA)/lib64 -lcublas -lcudart
 LIB += -lnvToolsExt

--- a/gpu/src/arch/polaris-gnu-nvcc
+++ b/gpu/src/arch/polaris-gnu-nvcc
@@ -17,14 +17,15 @@ CXXFLAGS += -D_CUDA_NVTX
 
 CUDA_CXXFLAGS = $(PYTHON_INC)
 CUDA_CXXFLAGS += -Xcompiler -fopenmp
-CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
+#CUDA_CXXFLAGS += -shared -Xcompiler -fPIC 
 CUDA_CXXFLAGS += -D_USE_GPU -D_GPU_CUDA
 CUDA_CXXFLAGS += -I/soft/compilers/cudatoolkit/cuda-11.4.4/include
 #CUDA_CXXFLAGS += -D_SIMPLE_TIMER
 CUDA_CXXFLAGS += -D_CUDA_NVTX
 
 LD = $(CXX)
-LDFLAGS = -fopenmp -fPIC -shared
+LDFLAGS = -fopenmp 
+LDFLAGS += -fPIC -shared
 
 LIB = -lstdc++
 LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran

--- a/gpu/src/arch/polaris-llvm
+++ b/gpu/src/arch/polaris-llvm
@@ -29,7 +29,8 @@ CUDA_CXXFLAGS += -D_SIMPLE_TIMER
 CUDA_CXXFLAGS += -D_CUDA_NVTX
 
 LD = $(CXX)
-LDFLAGS = -fPIC -shared $(GPU_FLAGS)
+LDFLAGS = $(GPU_FLAGS)
+#LDFLAGS = -fPIC -shared
 LIB = -lstdc++
 LIB += -L$(CUDA)/lib64 -lcublas -lcudart
 LIB += -lnvToolsExt

--- a/gpu/src/arch/polaris-nvhpc-openmp
+++ b/gpu/src/arch/polaris-nvhpc-openmp
@@ -32,7 +32,8 @@ CXXFLAGS += -D_SIMPLE_TIMER
 CXXFLAGS += -D_CUDA_NVTX
 
 LD = $(CXX)
-LDFLAGS = $(GPU_FLAGS) -fPIC -shared
+LDFLAGS = $(GPU_FLAGS)
+#LDFLAGS += -fPIC -shared
 LIB = -lstdc++
 LIB += $(PYTHON_LIB)
 LIB += -L/home/knight/soft/polaris/lapack/lib -llapack -lrefblas -lgfortran

--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -74,6 +74,26 @@ Device::Device()
   num_threads = omp_get_num_threads();
 
   num_devices = pm->dev_num_devices();
+
+  size_rho_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_vj_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_vk_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_buf_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_dms_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_dmtril_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_eri1_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  size_tril_map_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+
+  for(int i=0; i<num_devices; ++i) {
+    size_rho_[i] = 0;
+    size_vj_[i] = 0;
+    size_vk_[i] = 0;
+    size_buf_[i] = 0;
+    size_dms_[i] = 0;
+    size_dmtril_[i] = 0;
+    size_eri1_[i] = 0;
+    size_tril_map_[i] = 0;
+  }
   
 #ifdef _SIMPLE_TIMER
   t_array_count = 0;
@@ -168,6 +188,8 @@ Device::~Device()
   pm->dev_free(d_bPpj);
   pm->dev_free(d_vPpj);
   pm->dev_free(d_vk_bj);
+
+  pm->dev_free_host(size_vj_);
   
 #ifdef _CUDA_NVTX
   nvtxRangePop();

--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -62,6 +62,8 @@ Device::Device()
   d_bPpj = nullptr;
   d_vPpj = nullptr;
   d_vk_bj = nullptr;
+
+  use_eri_cache = true;
 #endif
   
   num_threads = 1;
@@ -127,20 +129,20 @@ Device::~Device()
 
   // print summary of cached eri blocks
 
-#ifdef _USE_ERI_CACHE
-  printf("LIBGPU::eri cache :: size= %i\n",eri_list.size());
-  for(int i=0; i<eri_list.size(); ++i)
-    printf("%i : eri= %p  Mbytes= %f  count= %i  update= %i\n", i, eri_list[i],
-	   eri_size[i]*sizeof(double)/1024./1024., eri_count[i], eri_update[i]);
-  
-  eri_count.clear();
-  eri_size.clear();
+  if(use_eri_cache) {
+    printf("LIBGPU::eri cache :: size= %i\n",eri_list.size());
+    for(int i=0; i<eri_list.size(); ++i)
+      printf("%i : eri= %p  Mbytes= %f  count= %i  update= %i\n", i, eri_list[i],
+	     eri_size[i]*sizeof(double)/1024./1024., eri_count[i], eri_update[i]);
+    
+    eri_count.clear();
+    eri_size.clear();
 #ifdef _DEBUG_ERI_CACHE
-  for(int i=0; i<d_eri_host.size(); ++i) pm->dev_free_host( d_eri_host[i] );
+    for(int i=0; i<d_eri_host.size(); ++i) pm->dev_free_host( d_eri_host[i] );
 #endif
-  for(int i=0; i<d_eri_cache.size(); ++i) pm->dev_free( d_eri_cache[i] );
-  eri_list.clear();
-#endif
+    for(int i=0; i<d_eri_cache.size(); ++i) pm->dev_free( d_eri_cache[i] );
+    eri_list.clear();
+  }
   
 #if defined(_USE_GPU)
 #ifdef _CUDA_NVTX

--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -4,7 +4,7 @@
 
 #include "device.h"
 
-#define _NUM_TIMER_JK 12
+#define _NUM_TIMER_JK 13
 
 /* ---------------------------------------------------------------------- */
 

--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -215,6 +215,13 @@ void Device::set_update_dfobj_(int _val)
 }
 
 /* ---------------------------------------------------------------------- */
+    
+void Device::disable_eri_cache_()
+{
+  use_eri_cache = false;
+}
+
+/* ---------------------------------------------------------------------- */
 
 // return stored values for Python side to make decisions
 // update_dfobj == true :: nothing useful to return if need to update eri blocks on device

--- a/gpu/src/device.cpp
+++ b/gpu/src/device.cpp
@@ -18,15 +18,15 @@ Device::Device()
 
   update_dfobj = 0;
   
-  size_rho = 0;
-  size_vj = 0;
-  size_vk = 0;
-  size_buf = 0;
-  size_fdrv = 0;
-  size_dms = 0;
-  size_dmtril = 0;
-  size_eri1 = 0;
-  size_tril_map = 0;
+  // size_rho = 0;
+  // size_vj = 0;
+  // size_vk = 0;
+  // size_buf = 0;
+  // size_fdrv = 0;
+  // size_dms = 0;
+  // size_dmtril = 0;
+  // size_eri1 = 0;
+  // size_tril_map = 0;
 
   size_bPpj = 0;
   size_vPpj = 0;
@@ -41,26 +41,26 @@ Device::Device()
   buf4 = nullptr;
 
   buf_fdrv = nullptr;
-  tril_map = nullptr;
+  //  tril_map = nullptr;
   
 #if defined(_USE_GPU)
-  handle = nullptr;
-  stream = nullptr;
+  //  handle = nullptr;
+  //  stream = nullptr;
 
-  handle_ = nullptr;
-  stream_ = nullptr;
+  //  handle_ = nullptr;
+  //  stream_ = nullptr;
 
-  d_rho = nullptr;
-  d_vj = nullptr;
-  d_buf1 = nullptr;
-  d_buf2 = nullptr;
-  d_buf3 = nullptr;
-  d_vkk = nullptr;
-  d_dms = nullptr;
-  d_dmtril = nullptr;
-  d_eri1 = nullptr;
+  // d_rho = nullptr;
+  // d_vj = nullptr;
+  // d_buf1 = nullptr;
+  // d_buf2 = nullptr;
+  // d_buf3 = nullptr;
+  // d_vkk = nullptr;
+  // d_dms = nullptr;
+  // d_dmtril = nullptr;
+  // d_eri1 = nullptr;
 
-  d_tril_map = nullptr;
+  // d_tril_map = nullptr;
 
   d_bPpj = nullptr;
   d_vPpj = nullptr;
@@ -74,25 +74,34 @@ Device::Device()
   num_threads = omp_get_num_threads();
 
   num_devices = pm->dev_num_devices();
-
-  size_rho_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_vj_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_vk_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_buf_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_dms_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_dmtril_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_eri1_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
-  size_tril_map_ = (int *) pm->dev_malloc_host(num_devices * sizeof(int));
+  
+  device_data = (my_device_data*) pm->dev_malloc_host(num_devices * sizeof(my_device_data));
 
   for(int i=0; i<num_devices; ++i) {
-    size_rho_[i] = 0;
-    size_vj_[i] = 0;
-    size_vk_[i] = 0;
-    size_buf_[i] = 0;
-    size_dms_[i] = 0;
-    size_dmtril_[i] = 0;
-    size_eri1_[i] = 0;
-    size_tril_map_[i] = 0;
+    device_data[i].size_rho = 0;
+    device_data[i].size_vj = 0;
+    device_data[i].size_vk = 0;
+    device_data[i].size_buf = 0;
+    device_data[i].size_dms = 0;
+    device_data[i].size_dmtril = 0;
+    device_data[i].size_eri1 = 0;
+    device_data[i].size_tril_map = 0;
+    
+    device_data[i].d_rho = nullptr;
+    device_data[i].d_vj = nullptr;
+    device_data[i].d_buf1 = nullptr;
+    device_data[i].d_buf2 = nullptr;
+    device_data[i].d_buf3 = nullptr;
+    device_data[i].d_vkk = nullptr;
+    device_data[i].d_dms = nullptr;
+    device_data[i].d_dmtril = nullptr;
+    device_data[i].d_eri1 = nullptr;
+    
+    device_data[i].tril_map = nullptr;
+    device_data[i].d_tril_map = nullptr;
+    
+    device_data[i].handle = nullptr;
+    device_data[i].stream = nullptr;
   }
   
 #ifdef _SIMPLE_TIMER
@@ -125,7 +134,7 @@ Device::~Device()
   pm->dev_free_host(buf4);
 
   pm->dev_free_host(buf_fdrv);
-  pm->dev_free_host(tril_map);
+  //  pm->dev_free_host(tril_map);
 
 #ifdef _SIMPLE_TIMER
   t_array_jk[11] += omp_get_wtime() - t0;
@@ -174,31 +183,34 @@ Device::~Device()
   nvtxRangePushA("Deallocate");
 #endif
 
-  pm->dev_free(d_rho);
-  pm->dev_free(d_vj);
-  pm->dev_free(d_buf1);
-  pm->dev_free(d_buf2);
-  pm->dev_free(d_buf3);
-  pm->dev_free(d_vkk);
-  pm->dev_free(d_dms);
-  pm->dev_free(d_dmtril);
-  pm->dev_free(d_eri1);
-  pm->dev_free(d_tril_map);
+  //  for(int i=0; i<num_devices; ++i) // free gpu objects
+  
+  // pm->dev_free(d_rho);
+  // pm->dev_free(d_vj);
+  // pm->dev_free(d_buf1);
+  // pm->dev_free(d_buf2);
+  // pm->dev_free(d_buf3);
+  // pm->dev_free(d_vkk);
+  // pm->dev_free(d_dms);
+  // pm->dev_free(d_dmtril);
+  // pm->dev_free(d_eri1);
+  // pm->dev_free(d_tril_map);
 
   pm->dev_free(d_bPpj);
   pm->dev_free(d_vPpj);
   pm->dev_free(d_vk_bj);
-
-  pm->dev_free_host(size_vj_);
   
 #ifdef _CUDA_NVTX
   nvtxRangePop();
   
   nvtxRangePushA("Destroy Handle");
 #endif
-  cublasDestroy(handle);
+  //  cublasDestroy(handle);
 
-  for(int i=0; i<num_devices; ++i) cublasDestroy(handle_[i]);
+  for(int i=0; i<num_devices; ++i) {
+    my_device_data * dd = &(device_data[i]);
+    cublasDestroy(dd->handle);
+  }
 #ifdef _CUDA_NVTX
   nvtxRangePop();
 #endif

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -95,25 +95,16 @@ private:
   // get_jk
 
   int update_dfobj;
-
-  int * size_rho_;
-  int * size_vj_;
-  int * size_vk_;
-  int * size_buf_;
-  int * size_dms_;
-  int * size_dmtril_;
-  int * size_eri1_;
-  int * size_tril_map_;
   
-  int size_rho;
-  int size_vj;
-  int size_vk;
-  int size_buf;
-  int size_fdrv;
-  int size_dms;
-  int size_dmtril;
-  int size_eri1;
-  int size_tril_map;
+  // int size_rho;
+  // int size_vj;
+  // int size_vk;
+  // int size_buf;
+  // int size_fdrv;
+  // int size_dms;
+  // int size_dmtril;
+  // int size_eri1;
+  // int size_tril_map;
 
   int blksize;
   int nao;
@@ -132,18 +123,18 @@ private:
   double * buf4;
   double * buf_fdrv;
 
-  double * d_rho;
-  double * d_vj;
-  double * d_buf1;
-  double * d_buf2;
-  double * d_buf3;
-  double * d_vkk;
-  double * d_dms;
-  double * d_dmtril;
-  double * d_eri1;
+  // double * d_rho;
+  // double * d_vj;
+  // double * d_buf1;
+  // double * d_buf2;
+  // double * d_buf3;
+  // double * d_vkk;
+  // double * d_dms;
+  // double * d_dmtril;
+  // double * d_eri1;
   
-  int * tril_map;
-  int * d_tril_map;
+  // int * tril_map;
+  // int * d_tril_map;
 
   // hessop_get_veff
 
@@ -192,6 +183,35 @@ private:
     //        CVHFOpt *vhfopt;
   };
 
+  struct my_device_data {
+    int size_rho;
+    int size_vj;
+    int size_vk;
+    int size_buf;
+    int size_dms;
+    int size_dmtril;
+    int size_eri1;
+    int size_tril_map;
+    
+    double * d_rho;
+    double * d_vj;
+    double * d_buf1;
+    double * d_buf2;
+    double * d_buf3;
+    double * d_vkk;
+    double * d_dms;
+    double * d_dmtril;
+    double * d_eri1;
+
+    int * tril_map;
+    int * d_tril_map;
+    
+    cublasHandle_t handle;
+    cudaStream_t stream;
+  };
+
+  my_device_data * device_data;
+    
   void fdrv(double *, double *, double *,
 	    int, int, int *, int *, int, double *);
   
@@ -217,11 +237,11 @@ private:
   int num_devices;
 
 #if defined(_USE_GPU)
-  cublasHandle_t handle;
-  cudaStream_t stream;
+  //  cublasHandle_t handle;
+  //  cudaStream_t stream;
   
-  cublasHandle_t * handle_;
-  cudaStream_t * stream_;
+  //  cublasHandle_t * handle_;
+  //  cudaStream_t * stream_;
 #endif
   
 };

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -95,6 +95,15 @@ private:
   // get_jk
 
   int update_dfobj;
+
+  int * size_rho_;
+  int * size_vj_;
+  int * size_vk_;
+  int * size_buf_;
+  int * size_dms_;
+  int * size_dmtril_;
+  int * size_eri1_;
+  int * size_tril_map_;
   
   int size_rho;
   int size_vj;

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -146,6 +146,8 @@ private:
   double * d_vk_bj;
   
   // eri caching on device
+
+  bool use_eri_cache;
   
   std::vector<size_t> eri_list; // addr of dfobj+eri1 for key-value pair
   

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -20,6 +20,7 @@ using namespace PM_NS;
 #define _SIZE_BLOCK 256
 
 #define _USE_ERI_CACHE
+#define _ERI_CACHE_EXTRA 2
 //#define _DEBUG_ERI_CACHE
 
 #define OUTPUTIJ        1
@@ -66,7 +67,9 @@ public :
 	      py::array_t<double>, py::array_t<double>,
 	      int, int, size_t);
   void pull_get_jk(py::array_t<double>, py::array_t<double>, int);
+  
   void set_update_dfobj_(int);
+  void get_dfobj_status(size_t, py::array_t<int>);
   
   void hessop_get_veff(int, int, int, int,
 		       py::array_t<double>, py::array_t<double>, py::array_t<double>);
@@ -149,6 +152,9 @@ private:
   std::vector<int> eri_count; // # times particular cache used
   std::vector<int> eri_update; // # times particular cache updated
   std::vector<int> eri_size; // # size of particular cache
+
+  std::vector<int> eri_num_blocks; // # of eri blocks for each dfobj (i.e. trip-count from `for eri1 in dfobj.loop(blksize)`)
+  std::vector<int> eri_extra; // per-block data: {naux, nao_pair}
 
   std::vector<double *> d_eri_cache; // pointers for device caches
   std::vector<double *> d_eri_host; // values on host for checking if update

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -87,6 +87,8 @@ private:
   class PM * pm;
   
   double host_compute(double *);
+  void get_cores(char *);
+  
   int n;
   int size_data;
 

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -64,8 +64,8 @@ public :
   void get_jk(int,
 	      py::array_t<double>, py::array_t<double>, py::list &,
 	      py::array_t<double>, py::array_t<double>,
-	      int, size_t);
-  void pull_get_jk(py::array_t<double>, py::array_t<double>);
+	      int, int, size_t);
+  void pull_get_jk(py::array_t<double>, py::array_t<double>, int);
   void set_update_dfobj_(int);
   
   void hessop_get_veff(int, int, int, int,

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -60,6 +60,7 @@ public :
   int get_num_devices();
   void get_dev_properties(int);
   void set_device(int);
+  void disable_eri_cache_();
 
   void init_get_jk(py::array_t<double>, py::array_t<double>, int, int, int, int, int);
   void get_jk(int,

--- a/gpu/src/device.h
+++ b/gpu/src/device.h
@@ -158,6 +158,7 @@ private:
 
   std::vector<int> eri_num_blocks; // # of eri blocks for each dfobj (i.e. trip-count from `for eri1 in dfobj.loop(blksize)`)
   std::vector<int> eri_extra; // per-block data: {naux, nao_pair}
+  std::vector<int> eri_device; // device id holding cache
 
   std::vector<double *> d_eri_cache; // pointers for device caches
   std::vector<double *> d_eri_host; // values on host for checking if update
@@ -204,10 +205,14 @@ private:
 #endif
 
   int num_threads;
-  
+  int num_devices;
+
 #if defined(_USE_GPU)
   cublasHandle_t handle;
   cudaStream_t stream;
+  
+  cublasHandle_t * handle_;
+  cudaStream_t * stream_;
 #endif
   
 };

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -15,7 +15,7 @@
 #define _HESSOP_BLOCK_SIZE 32
 #define _DEFAULT_BLOCK_SIZE 32
 
-#define _DEBUG_DEVICE
+//#define _DEBUG_DEVICE
 
 #define _TILE(A,B) (A + B - 1) / B
 
@@ -260,7 +260,7 @@ void Device::pull_get_jk(py::array_t<double> _vj, py::array_t<double> _vk, int w
     pm->dev_stream_wait(dd->stream);
     
     if(i == 0) pm->dev_pull(dd->d_vj, vj, nset * nao_pair * sizeof(double));
-    else {
+    else if(dd->d_vj) {
       pm->dev_pull(dd->d_vj, tmp, nset*nao_pair*sizeof(double));
       for(int j=0; j<nset*nao_pair; ++j) vj[j] += tmp[j];
     }
@@ -285,7 +285,7 @@ void Device::pull_get_jk(py::array_t<double> _vj, py::array_t<double> _vk, int w
       pm->dev_stream_wait(dd->stream);
 
       if(i == 0) pm->dev_pull(dd->d_vkk, vk, nset * nao * nao * sizeof(double));
-      else {
+      else if(dd->d_vkk) {
 	pm->dev_pull(dd->d_vkk, tmp, nset*nao*nao*sizeof(double));
 	for(int j=0; j<nset*nao*nao; ++j) vk[j] += tmp[j];
       }
@@ -536,7 +536,7 @@ void Device::get_jk(int naux,
     dd->d_rho = (double *) pm->dev_malloc(_size_rho * sizeof(double));
   }
 
-#if 1
+#if 0
   py::buffer_info info_vj = _vj.request(); // 2D array (nset, nao_pair)
   //  double * vj = static_cast<double*>(info_vj.ptr);
   

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -477,7 +477,8 @@ void Device::get_jk(int naux,
 
 #ifdef _USE_ERI_CACHE
 
-  // retrieve or cache eri block
+  // retrieve id of cached eri block
+
   int id = eri_list.size();
   for(int i=0; i<eri_list.size(); ++i)
     if(eri_list[i] == addr_dfobj+count) {
@@ -485,6 +486,8 @@ void Device::get_jk(int naux,
       break;
     }
 
+  // grab/update cached data
+  
   if(id < eri_list.size()) {
     eri_count[id]++;
     d_eri = d_eri_cache[id];
@@ -534,6 +537,12 @@ void Device::get_jk(int naux,
     eri_count.push_back(1);
     eri_update.push_back(0);
     eri_size.push_back(naux * nao_pair);
+
+    eri_num_blocks.push_back(0); // grow array
+    eri_num_blocks[id-count]++;  // increment # of blocks for this dfobj
+
+    eri_extra.push_back(naux);
+    eri_extra.push_back(nao_pair);
     
     d_eri_cache.push_back( (double *) pm->dev_malloc(naux * nao_pair * sizeof(double)) );
     int id = d_eri_cache.size() - 1;

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -128,6 +128,10 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
     if(d_eri1) pm->dev_free(d_eri1);
     d_eri1 = (double *) pm->dev_malloc(size_eri1 * sizeof(double));
   }
+
+#ifdef _SIMPLE_TIMER
+  double t1 = omp_get_wtime();
+#endif
   
   int _size_tril_map = nao * nao;
   //  if(_size_tril_map > size_tril_map) {
@@ -154,8 +158,10 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
   }
   
 #ifdef _SIMPLE_TIMER
-  double t1 = omp_get_wtime();
-  t_array_jk[0] += t1 - t0;
+  double t2 = omp_get_wtime();
+  t_array_jk[0] += t2 - t0;
+
+  t_array_jk[12] += t2 - t1;
 #endif
   
   // Create cuda stream
@@ -746,7 +752,7 @@ void Device::get_jk(int naux,
 #endif
 
     //    printf(" -- calling dev_stream_wait()\n");
-    pm->dev_stream_wait(stream);
+    //    pm->dev_stream_wait(stream);
     
 #ifdef _CUDA_NVTX
     nvtxRangePop();

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -15,7 +15,7 @@
 #define _HESSOP_BLOCK_SIZE 32
 #define _DEFAULT_BLOCK_SIZE 32
 
-//#define _DEBUG_DEVICE
+#define _DEBUG_DEVICE
 
 #define _TILE(A,B) (A + B - 1) / B
 
@@ -536,7 +536,7 @@ void Device::get_jk(int naux,
     dd->d_rho = (double *) pm->dev_malloc(_size_rho * sizeof(double));
   }
 
-#if 0
+#if 1
   py::buffer_info info_vj = _vj.request(); // 2D array (nset, nao_pair)
   //  double * vj = static_cast<double*>(info_vj.ptr);
   
@@ -1109,7 +1109,7 @@ void Device::hessop_get_veff(int naux, int nmo, int ncore, int nocc,
   
   int _size_buf = naux * nmo * nocc;
   if(_size_buf > dd->size_buf) {
-#if _DEBUG_DEVICE
+#ifdef _DEBUG_DEVICE
     printf("LIBGPU :: updating buffer sizes\n");
 #endif
     dd->size_buf = _size_buf;

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -409,7 +409,7 @@ void Device::get_jk(int naux,
 		    int with_k, int count, size_t addr_dfobj)
 {
 #ifdef _DEBUG_DEVICE
-  printf("Inside Device::get_jk()\n");
+  printf("Inside Device::get_jk() w/ with_k= %i\n",with_k);
 #endif
   
 #ifdef _SIMPLE_TIMER
@@ -592,7 +592,12 @@ void Device::get_jk(int naux,
 #endif
   }
 
-  if(!with_k) return;
+  if(!with_k) {
+#ifdef _DEBUG_DEVICE
+    printf(" -- Leaving Device::get_jk()\n");
+#endif
+    return;
+  }
   
   // buf2 = lib.unpack_tril(eri1, out=buf[1])
   

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -48,18 +48,18 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
   //  double * dmtril = static_cast<double*>(info_dmtril.ptr);
   
   int _size_vj = nset * nao_pair;
-  if(_size_vj > size_vj) {
-    size_vj = _size_vj;
+  if(_size_vj > size_vj_[device_id]) {
+    size_vj_[device_id] = _size_vj;
     //if(vj) pm->dev_free_host(vj);
     //vj = (double *) pm->dev_malloc_host(size_vj * sizeof(double));
     if(d_vj) pm->dev_free(d_vj);
-    d_vj = (double *) pm->dev_malloc(size_vj * sizeof(double));
+    d_vj = (double *) pm->dev_malloc(_size_vj * sizeof(double));
   }
   //for(int i=0; i<_size_vj; ++i) vj[i] = 0.0;
   
   int _size_vk = nset * nao * nao;
-  if(_size_vk > size_vk) {
-    size_vk = _size_vk;
+  if(_size_vk > size_vk_[device_id]) {
+    size_vk_[device_id] = _size_vk;
     //    if(_vktmp) pm->dev_free_host(_vktmp);
     //    _vktmp = (double *) pm->dev_malloc_host(size_vk*sizeof(double));
 
@@ -68,7 +68,7 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
 #endif
     
     if(d_vkk) pm->dev_free(d_vkk);
-    d_vkk = (double *) pm->dev_malloc(size_vk * sizeof(double));
+    d_vkk = (double *) pm->dev_malloc(_size_vk * sizeof(double));
 
 #ifdef _CUDA_NVTX
     nvtxRangePop();
@@ -77,15 +77,15 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
   //  for(int i=0; i<_size_vk; ++i) _vktmp[i] = 0.0;
 
   int _size_buf = blksize * nao * nao;
-  if(_size_buf > size_buf) {
-    size_buf = _size_buf;
+  if(_size_buf > size_buf_[device_id]) {
+    size_buf_[device_id] = _size_buf;
     if(buf_tmp) pm->dev_free_host(buf_tmp);
     if(buf3) pm->dev_free_host(buf3);
     if(buf4) pm->dev_free_host(buf4);
     
-    buf_tmp = (double*) pm->dev_malloc_host(2*size_buf*sizeof(double));
-    buf3 = (double *) pm->dev_malloc_host(size_buf*sizeof(double)); // (nao, blksize*nao)
-    buf4 = (double *) pm->dev_malloc_host(size_buf*sizeof(double)); // (blksize*nao, nao)
+    buf_tmp = (double*) pm->dev_malloc_host(2*_size_buf*sizeof(double));
+    buf3 = (double *) pm->dev_malloc_host(_size_buf*sizeof(double)); // (nao, blksize*nao)
+    buf4 = (double *) pm->dev_malloc_host(_size_buf*sizeof(double)); // (blksize*nao, nao)
 
 #ifdef _CUDA_NVTX
     nvtxRangePushA("Realloc");
@@ -95,41 +95,41 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
     if(d_buf2) pm->dev_free(d_buf2);
     if(d_buf3) pm->dev_free(d_buf3);
     
-    d_buf1 = (double *) pm->dev_malloc(size_buf * sizeof(double));
-    d_buf2 = (double *) pm->dev_malloc(size_buf * sizeof(double));
-    d_buf3 = (double *) pm->dev_malloc(size_buf * sizeof(double));
+    d_buf1 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
+    d_buf2 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
+    d_buf3 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
 
 #ifdef _CUDA_NVTX
     nvtxRangePop();
 #endif
   }
 
-  int _size_fdrv = nao * nao * num_threads;
-  if(_size_fdrv > size_fdrv) {
-    size_fdrv = _size_fdrv;
-    if(buf_fdrv) pm->dev_free_host(buf_fdrv);
-    buf_fdrv = (double *) pm->dev_malloc_host(size_fdrv*sizeof(double));
-  }
+  // int _size_fdrv = nao * nao * num_threads;
+  // if(_size_fdrv > size_fdrv) {
+  //   size_fdrv = _size_fdrv;
+  //   if(buf_fdrv) pm->dev_free_host(buf_fdrv);
+  //   buf_fdrv = (double *) pm->dev_malloc_host(size_fdrv*sizeof(double));
+  // }
 
   int _size_dms = nao * nao;
-  if(_size_dms > size_dms) {
-    size_dms = _size_dms;
+  if(_size_dms > size_dms_[device_id]) {
+    size_dms_[device_id] = _size_dms;
     if(d_dms) pm->dev_free(d_dms);
-    d_dms = (double *) pm->dev_malloc(size_dms * sizeof(double));
+    d_dms = (double *) pm->dev_malloc(_size_dms * sizeof(double));
   }
 
   int _size_dmtril = nset * nao_pair;
-  if(_size_dmtril > size_dmtril) {
-    size_dmtril = _size_dmtril;
+  if(_size_dmtril > size_dmtril_[device_id]) {
+    size_dmtril_[device_id] = _size_dmtril;
     if(d_dmtril) pm->dev_free(d_dmtril);
-    d_dmtril = (double *) pm->dev_malloc(size_dmtril * sizeof(double));
+    d_dmtril = (double *) pm->dev_malloc(_size_dmtril * sizeof(double));
   }
   
   int _size_eri1 = naux * nao_pair;
-  if(_size_eri1 > size_eri1) {
-    size_eri1 = _size_eri1;
+  if(_size_eri1 > size_eri1_[device_id]) {
+    size_eri1_[device_id] = _size_eri1;
     if(d_eri1) pm->dev_free(d_eri1);
-    d_eri1 = (double *) pm->dev_malloc(size_eri1 * sizeof(double));
+    d_eri1 = (double *) pm->dev_malloc(_size_eri1 * sizeof(double));
   }
 
 #ifdef _SIMPLE_TIMER
@@ -138,15 +138,15 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
   
   int _size_tril_map = nao * nao;
   //  if(_size_tril_map > size_tril_map) {
-  if(_size_tril_map != size_tril_map) {
+  if(_size_tril_map != size_tril_map_[device_id]) {
     // nao can change between calls, so mapping needs to be updated...
     // I think there are only two mappings needed
     
-    size_tril_map = _size_tril_map;
+    size_tril_map_[device_id] = _size_tril_map;
     if(tril_map) pm->dev_free_host(tril_map);
     if(d_tril_map) pm->dev_free(d_tril_map);
-    tril_map = (int *) pm->dev_malloc_host(size_tril_map * sizeof(int));
-    d_tril_map = (int *) pm->dev_malloc(size_tril_map * sizeof(int));
+    tril_map = (int *) pm->dev_malloc_host(_size_tril_map * sizeof(int));
+    d_tril_map = (int *) pm->dev_malloc(_size_tril_map * sizeof(int));
 
     // optimize map later...
 
@@ -158,7 +158,7 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
       }
     
     //pm->dev_push_async(d_tril_map, tril_map, size_tril_map*sizeof(int), stream); // how did this work w/o stream creation?
-    pm->dev_push(d_tril_map, tril_map, size_tril_map*sizeof(int));
+    pm->dev_push(d_tril_map, tril_map, _size_tril_map*sizeof(int));
   }
   
 #ifdef _SIMPLE_TIMER
@@ -167,6 +167,8 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
 
   t_array_jk[12] += t2 - t1;
 #endif
+
+  // 1-time initialization
   
   // Create cuda stream
   
@@ -176,7 +178,10 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
     stream_ = (cudaStream_t*) pm->dev_malloc_host(num_devices * sizeof(cudaStream_t));
 
     //    for(int i=0; i<num_devices; ++i) stream_[i] = stream; // tempory
-    for(int i=0; i<num_devices; ++i) pm->dev_stream_create(stream_[i]);
+    for(int i=0; i<num_devices; ++i) {
+      pm->dev_set_device(i);
+      pm->dev_stream_create(stream_[i]);
+    }
   }
   
   // Create blas handle
@@ -187,13 +192,18 @@ void Device::init_get_jk(py::array_t<double> _eri1, py::array_t<double> _dmtril,
 #endif
     cublasCreate(&handle);
     _CUDA_CHECK_ERRORS();
+    
     cublasSetStream(handle, stream);
     _CUDA_CHECK_ERRORS();
 
     handle_ = (cublasHandle_t*) pm->dev_malloc_host(num_devices * sizeof(cublasHandle_t));
+    
     for(int i=0; i<num_devices; ++i) {
+      pm->dev_set_device(i);
+      
       cublasCreate(&(handle_[i]));
       _CUDA_CHECK_ERRORS();
+      
       cublasSetStream(handle_[i], stream_[i]);
       _CUDA_CHECK_ERRORS();
     }
@@ -445,6 +455,7 @@ void Device::get_jk(int naux,
 #endif
 
   const int device_id = count % num_devices;
+  pm->dev_set_device(device_id);
     
   const int with_j = 1;
   
@@ -464,13 +475,13 @@ void Device::get_jk(int naux,
     d_eri = d_eri1;
   }
 
-  if(count == 0) pm->dev_push_async(d_dmtril, dmtril, nset * nao_pair * sizeof(double), stream_[device_id]);
+  if(count < num_devices) pm->dev_push_async(d_dmtril, dmtril, nset * nao_pair * sizeof(double), stream_[device_id]);
   
   int _size_rho = nset * naux;
-  if(_size_rho > size_rho) {
-    size_rho = _size_rho;
+  if(_size_rho > size_rho_[device_id]) {
+    size_rho_[device_id] = _size_rho;
     if(d_rho) pm->dev_free(d_rho);
-    d_rho = (double *) pm->dev_malloc(size_rho * sizeof(double));
+    d_rho = (double *) pm->dev_malloc(_size_rho * sizeof(double));
   }
 
 #if 0
@@ -980,6 +991,7 @@ void Device::hessop_get_veff(int naux, int nmo, int ncore, int nocc,
   double * vk_bj = static_cast<double*>(info_vk_bj.ptr);
 
   const int device_id = 0; //count % num_devices;
+  pm->dev_set_device(device_id);
   
   int nvirt = nmo - ncore;
 
@@ -997,23 +1009,23 @@ void Device::hessop_get_veff(int naux, int nmo, int ncore, int nocc,
   // this buf realloc needs to be consistent with that in init_get_jk()
   
   int _size_buf = naux * nmo * nocc;
-  if(_size_buf > size_buf) {
-    size_buf = _size_buf;
+  if(_size_buf > size_buf_[device_id]) {
+    size_buf_[device_id] = _size_buf;
     if(buf_tmp) pm->dev_free_host(buf_tmp);
     if(buf3) pm->dev_free_host(buf3);
     if(buf4) pm->dev_free_host(buf4);
     
-    buf_tmp = (double*) pm->dev_malloc_host(2*size_buf*sizeof(double));
-    buf3 = (double *) pm->dev_malloc_host(size_buf*sizeof(double));
-    buf4 = (double *) pm->dev_malloc_host(size_buf*sizeof(double));
+    buf_tmp = (double*) pm->dev_malloc_host(2*_size_buf*sizeof(double));
+    buf3 = (double *) pm->dev_malloc_host(_size_buf*sizeof(double));
+    buf4 = (double *) pm->dev_malloc_host(_size_buf*sizeof(double));
 
     if(d_buf1) pm->dev_free(d_buf1);
     if(d_buf2) pm->dev_free(d_buf2);
     if(d_buf3) pm->dev_free(d_buf3);
     
-    d_buf1 = (double *) pm->dev_malloc(size_buf * sizeof(double));
-    d_buf2 = (double *) pm->dev_malloc(size_buf * sizeof(double));
-    d_buf3 = (double *) pm->dev_malloc(size_buf * sizeof(double));
+    d_buf1 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
+    d_buf2 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
+    d_buf3 = (double *) pm->dev_malloc(_size_buf * sizeof(double));
   }
   
    int _size_vPpj = naux * nmo * nocc;

--- a/gpu/src/device_cuda.cpp
+++ b/gpu/src/device_cuda.cpp
@@ -336,24 +336,21 @@ __global__ void _getjk_unpack_buf2(double * buf2, double * eri1, int * map, int 
 
 /* ---------------------------------------------------------------------- */
 
-#if 0
+#if 1
 
-__global__ void _getjk_transpose_buf1_buf3(double * buf3, double * buf1, int naux, int nao)
+__global__ void _transpose(double * buf3, double * buf1, int nrow, int ncol)
 {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  const int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-  if(i >= naux) return;
-  if(j >= nao) return;
+  if(i >= nrow) return;
 
-  int k = blockIdx.z * blockDim.z + threadIdx.z;
-  const int indx = (i * nao + j) * nao;
+  int j = blockIdx.y * blockDim.y + threadIdx.y;
   
-  while (k < nao) {
-    buf3[k * (naux*nao) + (i*nao+j)] = buf1[indx + k]; // these writes should be to SLM and then contiguous chunks written to global memory
-    k += blockDim.z;
+  while (j < ncol) {
+    buf3[j*nrow + i] = buf1[i*ncol + j]; // these writes should be to SLM and then contiguous chunks written to global memory
+    j += blockDim.y;
   }
-
+  
 }
 
 #else
@@ -666,16 +663,19 @@ void Device::get_jk(int naux,
 #endif
     
     {
-#if 0
-      dim3 grid_size(naux, nao, 1);
-      dim3 block_size(1, 1,  _TRANSPOSE_BLOCK_SIZE);
+#if 1
+      dim3 grid_size(naux*nao, 1, 1);
+      dim3 block_size(1, _TRANSPOSE_BLOCK_SIZE, 1);
+      
+      _transpose<<<grid_size, block_size, 0, stream>>>(d_buf3, d_buf1, naux*nao, nao);
 #else
       dim3 grid_size((naux + (_TRANSPOSE_BLOCK_SIZE - 1)) / _TRANSPOSE_BLOCK_SIZE,
 		     (nao + (_TRANSPOSE_BLOCK_SIZE - 1)) / _TRANSPOSE_BLOCK_SIZE, 1);
       dim3 block_size(_TRANSPOSE_BLOCK_SIZE, _TRANSPOSE_BLOCK_SIZE, 1);
-#endif
       
       _getjk_transpose_buf1_buf3<<<grid_size, block_size, 0, stream>>>(d_buf3, d_buf1, naux, nao);
+#endif
+      
     }
     
     // vk[k] += lib.dot(buf3, buf4)

--- a/gpu/src/device_host.cpp
+++ b/gpu/src/device_host.cpp
@@ -82,7 +82,7 @@ void Device::pull_get_jk(py::array_t<double> _vj, py::array_t<double> _vk) {}
 void Device::get_jk(int naux,
 		    py::array_t<double> _eri1, py::array_t<double> _dmtril, py::list & _dms_list,
 		    py::array_t<double> _vj, py::array_t<double> _vk,
-		    int count, size_t addr_dfobj)
+		    int with_k, int count, size_t addr_dfobj)
 {  
 #ifdef _SIMPLE_TIMER
   double t0 = omp_get_wtime();
@@ -164,6 +164,8 @@ void Device::get_jk(int naux,
 #endif
   }
 
+  if(!with_k) return;
+  
   double * buf1 = buf_tmp;
   double * buf2 = &(buf_tmp[blksize * nao * nao]);
 

--- a/gpu/src/libgpu.cpp
+++ b/gpu/src/libgpu.cpp
@@ -113,6 +113,14 @@ void libgpu_set_update_dfobj_(void * ptr, int update_dfobj)
 
 /* ---------------------------------------------------------------------- */
 
+void libgpu_get_dfobj_status(void * ptr, size_t addr_dfobj, py::array_t<int> arg)
+{ 
+  Device * dev = (Device *) ptr;
+  dev->get_dfobj_status(addr_dfobj, arg);
+}
+
+/* ---------------------------------------------------------------------- */
+
 void libgpu_hessop_get_veff(void * ptr,
 			    int naux, int nmo, int ncore, int nocc,
 			    py::array_t<double> bPpj, py::array_t<double> vPpj, py::array_t<double> vk_bj)

--- a/gpu/src/libgpu.cpp
+++ b/gpu/src/libgpu.cpp
@@ -71,6 +71,14 @@ void libgpu_set_device(void * ptr, int id)
 
 /* ---------------------------------------------------------------------- */
 
+void libgpu_disable_eri_cache_(void * ptr)
+{ 
+  Device * dev = (Device *) ptr;
+  dev->disable_eri_cache_();
+}
+
+/* ---------------------------------------------------------------------- */
+
 void libgpu_init_get_jk(void * ptr,
 			py::array_t<double> eri1, py::array_t<double> dmtril, 
 			int blksize, int nset, int nao, int naux, int count)

--- a/gpu/src/libgpu.cpp
+++ b/gpu/src/libgpu.cpp
@@ -85,22 +85,22 @@ void libgpu_compute_get_jk(void * ptr,
 			   int naux,
 			   py::array_t<double> eri1, py::array_t<double> dmtril, py::list & dms,
 			   py::array_t<double> vj, py::array_t<double> vk,
-			   int count, size_t addr_dfobj)
+			   int with_k, int count, size_t addr_dfobj)
 { 
   Device * dev = (Device *) ptr;
   dev->get_jk(naux,
 	      eri1, dmtril, dms,
 	      vj, vk,
-	      count, addr_dfobj);
+	      with_k, count, addr_dfobj);
  
 }
 
 /* ---------------------------------------------------------------------- */
 
-void libgpu_pull_get_jk(void * ptr, py::array_t<double> vj, py::array_t<double> vk)
+void libgpu_pull_get_jk(void * ptr, py::array_t<double> vj, py::array_t<double> vk, int with_k)
 { 
   Device * dev = (Device *) ptr;
-  dev->pull_get_jk(vj, vk);
+  dev->pull_get_jk(vj, vk, with_k);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -20,6 +20,8 @@ extern "C"
   void libgpu_dev_properties(void *, int);
   void libgpu_set_device(void *, int);
 
+  void libgpu_disable_eri_cache_(void *);
+  
   void libgpu_init_get_jk(void *,
 			  py::array_t<double>, py::array_t<double>, int, int, int, int, int);
 
@@ -59,6 +61,7 @@ PYBIND11_MODULE(libgpu, m) {
   m.def("libgpu_get_num_devices", &libgpu_get_num_devices, "return number of devices present");
   m.def("libgpu_dev_properties", &libgpu_dev_properties, "info on available devices");
   m.def("libgpu_set_device", &libgpu_set_device, "select device");
+  m.def("libgpu_disable_eri_cache_", &libgpu_disable_eri_cache_, "disable caching eri blocks to reduce memory usage for get_jk");
 
   m.def("libgpu_compute_get_jk", &libgpu_compute_get_jk, "pyscf/df/df_jk.py::get_jk()");
   m.def("libgpu_init_get_jk", &libgpu_init_get_jk, "alloc for get_jk()");

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -27,9 +27,9 @@ extern "C"
 			     int,
 			     py::array_t<double>, py::array_t<double>, py::list &,
 			     py::array_t<double>, py::array_t<double>,
-			     int, size_t);
+			     int, int, size_t);
   
-  void libgpu_pull_get_jk(void *, py::array_t<double>, py::array_t<double>);
+  void libgpu_pull_get_jk(void *, py::array_t<double>, py::array_t<double>, int);
   void libgpu_set_update_dfobj_(void *, int);
   
   void libgpu_hessop_get_veff(void *,

--- a/gpu/src/libgpu.h
+++ b/gpu/src/libgpu.h
@@ -30,7 +30,9 @@ extern "C"
 			     int, int, size_t);
   
   void libgpu_pull_get_jk(void *, py::array_t<double>, py::array_t<double>, int);
+  
   void libgpu_set_update_dfobj_(void *, int);
+  void libgpu_get_dfobj_status(void *, size_t, py::array_t<int>);
   
   void libgpu_hessop_get_veff(void *,
 			      int, int, int, int,
@@ -61,7 +63,9 @@ PYBIND11_MODULE(libgpu, m) {
   m.def("libgpu_compute_get_jk", &libgpu_compute_get_jk, "pyscf/df/df_jk.py::get_jk()");
   m.def("libgpu_init_get_jk", &libgpu_init_get_jk, "alloc for get_jk()");
   m.def("libgpu_pull_get_jk", &libgpu_pull_get_jk, "retrieve vj & vk from get_jk()");
+  
   m.def("libgpu_set_update_dfobj_", &libgpu_set_update_dfobj_, "ensure that eri is updated on device for get_jk");
+  m.def("libgpu_get_dfobj_status", &libgpu_get_dfobj_status, "retrieve info on dfobj and cached eri blocks on device");
 
   m.def("libgpu_hessop_get_veff", &libgpu_hessop_get_veff, "lasci_sync.py::get_veff() for HessianOperator");
   m.def("libgpu_hessop_push_bPpj", &libgpu_hessop_push_bPpj, "bPpj array for HessianOperator");

--- a/my_pyscf/grad/lasscf.py
+++ b/my_pyscf/grad/lasscf.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#
+
+'''
+CASSCF analytical nuclear gradients
+
+Ref.
+J. Comput. Chem., 5, 589
+
+MRH: copied from pyscf.grad.casscf.py on 12/07/2019
+Contains my modifications for SA-CASSCF gradients
+1. Generalized Fock has nonzero i->a and u->a
+2. Memory footprint for differentiated eris bugfix
+'''
+
+'''
+SV: added and modified for casscf.py for lasscf nuclear gradients
+Also check lasscf_sync_o0.py where a nuc_grad_method has been defined with a Gradients class!
+'''
+
+from functools import reduce
+import numpy
+from pyscf import gto
+from pyscf import lib
+from pyscf import ao2mo
+from pyscf.lib import logger
+from pyscf.grad import casci as casci_grad
+from pyscf.grad import rhf as rhf_grad  # noqa
+from pyscf.grad.mp2 import _shell_prange
+from pyscf.mcscf.addons import StateAverageMCSCFSolver
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
+
+def grad_elec(las_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    las =las_grad.base
+    print (las)
+    if mo_coeff is None: mo_coeff = las.mo_coeff
+    #if ci is None: ci = mc.ci
+    #if mc.frozen is not None:
+        #raise NotImplementedError
+
+    time0 = logger.process_clock(), logger.perf_counter()
+    log = logger.new_logger(las_grad, verbose)
+    mol = las_grad.mol
+    ncore = las.ncore
+    ncas = las.ncas
+    nocc = ncore + ncas
+    nelecas = las.nelecas
+    nao, nmo = mo_coeff.shape
+    nao_pair = nao * (nao+1) // 2
+
+    # Necessary kludge because gfock isn't zero in occ-virt space in SA-CASSCf
+    # Among many other potential applications!
+    if hasattr (las, '_tag_gfock_ov_nonzero'):
+        if las._tag_gfock_ov_nonzero:
+            nocc = nmo
+
+    mo_occ = mo_coeff[:,:nocc]
+    mo_core = mo_coeff[:,:ncore]
+    mo_cas = mo_coeff[:,ncore:nocc]
+    #print ("SV nocc, ncas, ncore = ", nocc, ncas, ncore)
+    #print ("mo_cas shape =", mo_cas.shape)
+    #print ("SV entering grad_elec in lasscf")
+    lasdm1 = las.make_casdm1()
+    #print ("SV lasdm1 shape = ",lasdm1.shape)
+    lasdm2 = las.make_casdm2()
+    #casdm1, casdm2 = mc.fcisolver.make_rdm12(ci, ncas, nelecas)
+
+# gfock = Generalized Fock, Adv. Chem. Phys., 69, 63
+    dm_core = numpy.dot(mo_core, mo_core.T) * 2
+    dm_cas = reduce(numpy.dot, (mo_cas, lasdm1, mo_cas.T))
+    # MRH flag: this is one of my kludges
+    # It would be better to just pass the ERIS object used in orbital optimization
+    # But I am too lazy at the moment
+    aapa = ao2mo.kernel(mol, (mo_cas, mo_cas, mo_occ, mo_cas), compact=False)
+    aapa = aapa.reshape(ncas,ncas,nocc,ncas)
+    vj, vk = las._scf.get_jk(mol, (dm_core, dm_cas))
+    h1 = las.get_hcore()
+    vhf_c = vj[0] - vk[0] * .5
+    vhf_a = vj[1] - vk[1] * .5
+    gfock = numpy.zeros ((nocc, nocc))
+    gfock[:,:ncore] = reduce(numpy.dot, (mo_occ.T, h1 + vhf_c + vhf_a, mo_core)) * 2
+    gfock[:,ncore:ncore+ncas] = reduce(numpy.dot, (mo_occ.T, h1 + vhf_c, mo_cas, lasdm1))
+    gfock[:,ncore:ncore+ncas] += numpy.einsum('uviw,vuwt->it', aapa, lasdm2)
+    dme0 = reduce(numpy.dot, (mo_occ, (gfock+gfock.T)*.5, mo_occ.T))
+    aapa = vj = vk = vhf_c = vhf_a = h1 = gfock = None
+
+    dm1 = dm_core + dm_cas
+    vj, vk = las_grad.get_jk(mol, (dm_core, dm_cas))
+    vhf1c, vhf1a = vj - vk * .5
+    hcore_deriv = las_grad.hcore_generator(mol)
+    s1 = las_grad.get_ovlp(mol)
+
+    diag_idx = numpy.arange(nao)
+    diag_idx = diag_idx * (diag_idx+1) // 2 + diag_idx
+    lasdm2_cc = lasdm2 + lasdm2.transpose(0,1,3,2)
+    dm2buf = ao2mo._ao2mo.nr_e2(lasdm2_cc.reshape(ncas**2,ncas**2), mo_cas.T,
+                                (0, nao, 0, nao)).reshape(ncas**2,nao,nao)
+    dm2buf = lib.pack_tril(dm2buf)
+    dm2buf[:,diag_idx] *= .5
+    dm2buf = dm2buf.reshape(ncas,ncas,nao_pair)
+    lasdm2 = lasdm2_cc = None
+
+    if atmlst is None:
+        atmlst = range(mol.natm)
+    aoslices = mol.aoslice_by_atom()
+    de = numpy.zeros((len(atmlst),3))
+
+    max_memory = las_grad.max_memory - lib.current_memory()[0]
+    # MRH: this originally implied that the memory footprint would be max(p1-p0) * max(q1-q0) * nao_pair
+    # In fact, that's the size of dm2_ao AND EACH COMPONENT of the differentiated eris
+    # So the actual memory footprint is 4 times that!
+    blksize = int(max_memory*.9e6/8 / (4*(aoslices[:,3]-aoslices[:,2]).max()*nao_pair))
+    blksize = min(nao, max(2, blksize))
+
+    for k, ia in enumerate(atmlst):
+        shl0, shl1, p0, p1 = aoslices[ia]
+        h1ao = hcore_deriv(ia)
+        de[k] += numpy.einsum('xij,ij->x', h1ao, dm1)
+        de[k] -= numpy.einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+
+        q1 = 0
+        for b0, b1, nf in _shell_prange(mol, 0, mol.nbas, blksize):
+            q0, q1 = q1, q1 + nf
+            dm2_ao = lib.einsum('ijw,pi,qj->pqw', dm2buf, mo_cas[p0:p1], mo_cas[q0:q1])
+            shls_slice = (shl0,shl1,b0,b1,0,mol.nbas,0,mol.nbas)
+            eri1 = mol.intor('int2e_ip1', comp=3, aosym='s2kl',
+                             shls_slice=shls_slice).reshape(3,p1-p0,nf,nao_pair)
+            de[k] -= numpy.einsum('xijw,ijw->x', eri1, dm2_ao) * 2
+            eri1 = None
+        de[k] += numpy.einsum('xij,ij->x', vhf1c[:,p0:p1], dm1[p0:p1]) * 2
+        de[k] += numpy.einsum('xij,ij->x', vhf1a[:,p0:p1], dm_core[p0:p1]) * 2
+
+    log.timer('CASSCF nuclear gradients', *time0)
+    return de
+
+def as_scanner(mcscf_grad):
+    '''Generating a nuclear gradients scanner/solver (for geometry optimizer).
+
+    The returned solver is a function. This function requires one argument
+    "mol" as input and returns energy and first order nuclear derivatives.
+
+    The solver will automatically use the results of last calculation as the
+    initial guess of the new calculation.  All parameters assigned in the
+    nuc-grad object and SCF object (DIIS, conv_tol, max_memory etc) are
+    automatically applied in the solver.
+
+    Note scanner has side effects.  It may change many underlying objects
+    (_scf, with_df, with_x2c, ...) during calculation.
+
+    Examples:
+
+    >>> from pyscf import gto, scf, mcscf
+    >>> mol = gto.M(atom='N 0 0 0; N 0 0 1.1', verbose=0)
+    >>> mc_grad_scanner = mcscf.CASSCF(scf.RHF(mol), 4, 4).nuc_grad_method().as_scanner()
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.1'))
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.5'))
+    '''
+    print ("SV Entering as_scanner in lasscf")
+    if isinstance(mcscf_grad, lib.GradScanner):
+        return mcscf_grad
+
+    logger.info(mcscf_grad, 'Create scanner for %s', mcscf_grad.__class__)
+    name = mcscf_grad.__class__.__name__ + LASSCF_GradScanner.__name_mixin__
+    return lib.set_class(LASSCF_GradScanner(mcscf_grad),
+                         (LASSCF_GradScanner, mcscf_grad.__class__), name)
+
+class LASSCF_GradScanner(lib.GradScanner):
+    def __init__(self, g):
+        lib.GradScanner.__init__(self, g)
+
+    def __call__(self, mol_or_geom, **kwargs):
+        if isinstance(mol_or_geom, gto.MoleBase):
+            assert mol_or_geom.__class__ == gto.Mole
+            mol = mol_or_geom
+        else:
+            mol = self.mol.set_geom_(mol_or_geom, inplace=False)
+        self.reset(mol)
+
+        mc_scanner = self.base
+        e_tot = mc_scanner(mol)
+        if isinstance(mc_scanner, StateAverageMCSCFSolver):
+            e_tot = mc_scanner.e_average
+
+        de = self.kernel(**kwargs)
+        return e_tot, de
+
+
+class Gradients(casci_grad.Gradients):
+    '''Non-relativistic restricted Hartree-Fock gradients'''
+    print ("SV entering Gradients in LASSCF")
+    grad_elec = grad_elec
+
+    def kernel(self, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+        print ("SV entering kernel")
+        log = logger.new_logger(self, verbose)
+        if atmlst is None:
+            atmlst = self.atmlst
+        else:
+            self.atmlst = atmlst
+
+        if self.verbose >= logger.WARN:
+            self.check_sanity()
+        if self.verbose >= logger.INFO:
+            self.dump_flags()
+
+        de = self.grad_elec(mo_coeff, ci, atmlst, log)
+        self.de = de = de + self.grad_nuc(atmlst=atmlst)
+        if self.mol.symmetry:
+            self.de = self.symmetrize(self.de, atmlst)
+        self._finalize()
+        return self.de
+   
+    def _finalize(self):
+        if self.verbose >= logger.NOTE:
+            logger.note(self, '--------------- %s gradients ---------------',
+                        self.base.__class__.__name__)
+            self._write(self.mol, self.de, self.atmlst)
+            logger.note(self, '----------------------------------------------')
+
+    as_scanner = as_scanner
+
+    to_gpu = lib.to_gpu
+
+#Grad = Gradients
+
+#from pyscf import mcscf
+#mcscf.mc1step.CASSCF.Gradients = lib.class_as_method(Gradients)                                                                                                                                             

--- a/my_pyscf/lassi/excitations.py
+++ b/my_pyscf/lassi/excitations.py
@@ -547,8 +547,9 @@ class VRVDressedFCISolver (object):
         e_pq = np.append ([e_p,], e_q)
         h_diagmin = np.amin (e_pq)
         if e0-h_diagmin > 1e-8:
-            log.warn ("%s in VRVSolver: min (hdiag) = %.6f < e0 = %.6f",
-                      warntag, np.amin (e_pq), e0)
+            if self.verbose >= lib.logger.DEBUG:
+                log.warn ("%s in VRVSolver: min (hdiag) = %.6f < e0 = %.6f",
+                          warntag, np.amin (e_pq), e0)
             log.debug ('e_p = %.6f ; vrv = %.6f', e_p, vrv)
             log.debug ('e_q = {}'.format (e_q))
             log.debug ('valid de_pq = {}'.format (de_pq[idx]))

--- a/my_pyscf/lassi/lassirq.py
+++ b/my_pyscf/lassi/lassirq.py
@@ -1,8 +1,9 @@
 import numpy as np
+from pyscf import lib,gto
 from pyscf.lib import logger
 from mrh.my_pyscf.lassi import LASSI
-from mrh.my_pyscf.lassi.states import spin_shuffle, spin_shuffle_ci
-from mrh.my_pyscf.lassi.states import all_single_excitations, SingleLASRootspace
+from mrh.my_pyscf.lassi.spaces import spin_shuffle, spin_shuffle_ci
+from mrh.my_pyscf.lassi.spaces import all_single_excitations, SingleLASRootspace
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 
 def prepare_states_spin_shuffle (lsi):
@@ -30,6 +31,54 @@ def make_lroots (lsi, las, q=None):
     ncsf = las.get_ugg ().ncsf_sub
     return np.minimum (ncsf, q)
 
+def as_scanner(lsi):
+    '''Generating a scanner for LASSIrq PES.
+    
+    The returned solver is a function. This function requires one argument
+    "mol" as input and returns total LASSIrq energy.
+
+    The solver will automatically use the results of last calculation as the
+    initial guess of the new calculation.  All parameters of LASSIrq object
+    are automatically applied in the solver.
+    
+    Note scanner has side effects.  It may change many underlying objects
+    (_scf, with_df, with_x2c, ...) during calculation.
+    ''' 
+    if isinstance(lsi, lib.SinglePointScanner):
+        return lsi
+        
+    logger.info(lsi, 'Create scanner for %s', lsi.__class__)
+    name = lsi.__class__.__name__ + LASSIrq_Scanner.__name_mixin__
+    return lib.set_class(LASSIrq_Scanner(lsi), (LASSIrq_Scanner, lsi.__class__), name)
+        
+class LASSIrq_Scanner(lib.SinglePointScanner):
+    def __init__(self, lsi, state=0):
+        self.__dict__.update(lsi.__dict__)
+        self._las = lsi._las.as_scanner()
+        self._scan_state = state
+
+    def __call__(self, mol_or_geom, **kwargs):
+        if isinstance(mol_or_geom, gto.MoleBase):
+            mol = mol_or_geom
+        else:
+            mol = self.mol.set_geom_(mol_or_geom, inplace=False)
+    
+        self.reset (mol)
+        for key in ('with_df', 'with_x2c', 'with_solvent', 'with_dftd3'):
+            sub_mod = getattr(self, key, None)
+            if sub_mod:
+                sub_mod.reset(mol)
+
+        las_scanner = self._las
+        las_scanner(mol)
+        self.mol = mol
+        self.mo_coeff = las_scanner.mo_coeff
+        e_tot = self.kernel()[0][self._scan_state]
+        if hasattr (e_tot, '__len__'):
+            e_tot = np.average (e_tot)
+        return e_tot
+
+
 class LASSIrq (LASSI):
     def __init__(self, las, r=0, q=1, opt=1, **kwargs):
         self.r = r
@@ -53,7 +102,7 @@ class LASSIrq (LASSI):
 
     make_lroots = make_lroots
     prepare_states = prepare_states
-
+    as_scanner=as_scanner
 class LASSIrqCT (LASSIrq):
     def make_lroots (self, las, q=None):
         lroots = LASSIrq.make_lroots (self, las, q=q)

--- a/my_pyscf/lassi/lassis.py
+++ b/my_pyscf/lassi/lassis.py
@@ -1,5 +1,6 @@
 import sys
 import numpy as np
+import itertools
 from scipy import linalg
 from pyscf import lib, gto
 from pyscf.lib import logger
@@ -10,8 +11,10 @@ from mrh.my_pyscf.fci.spin_op import contract_sdown, contract_sup
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 from mrh.my_pyscf.mcscf.productstate import ProductStateFCISolver
 from mrh.my_pyscf.lassi.excitations import ExcitationPSFCISolver
-from mrh.my_pyscf.lassi.states import spin_shuffle, spin_shuffle_ci
-from mrh.my_pyscf.lassi.states import all_single_excitations, SingleLASRootspace
+from mrh.my_pyscf.lassi.spaces import spin_shuffle, spin_shuffle_ci
+from mrh.my_pyscf.lassi.spaces import _spin_shuffle
+from mrh.my_pyscf.lassi.spaces import all_single_excitations, SingleLASRootspace
+from mrh.my_pyscf.lassi.spaces import orthogonal_excitations, combine_orthogonal_excitations
 from mrh.my_pyscf.lassi.lassi import LASSI
 
 # TODO: split prepare_states into three steps
@@ -27,6 +30,7 @@ from mrh.my_pyscf.lassi.lassi import LASSI
 def prepare_states (lsi, ncharge=1, nspin=0, sa_heff=True, deactivate_vrv=False, crash_locmin=False):
     # TODO: make states_energy_elec capable of handling lroots and address inconsistency
     # between definition of e_states array for neutral and charge-separated rootspaces
+    t0 = (logger.process_clock (), logger.perf_counter ())
     log = logger.new_logger (lsi, lsi.verbose)
     las = lsi._las.get_single_state_las (state=0)
     # 1. Spin shuffle step
@@ -53,20 +57,30 @@ def prepare_states (lsi, ncharge=1, nspin=0, sa_heff=True, deactivate_vrv=False,
     # like spin_flips above.
     if ncharge:
         las2 = all_single_excitations (las1)
-        converged, las2.ci, las2.e_states = single_excitations_ci (
+        converged, spaces2 = single_excitations_ci (
             lsi, las2, las1, ncharge=ncharge, sa_heff=sa_heff, deactivate_vrv=deactivate_vrv,
             spin_flips=spin_flips, crash_locmin=crash_locmin
         )
     else:
-        converged, las2 = las1.converged, las1
+        converged = las1.converged
+        spaces2 = [SingleLASRootspace (las1, m, s, c, las1.weights[ix], ci=[c[ix] for c in las1.ci])
+                   for ix, (c, m, s, w) in enumerate (zip (*get_space_info (las1)))]
     if lsi.nfrags > 3:
-        las2 = charge_excitation_products (las2, las1)
+        spaces2 = charge_excitation_products (lsi, spaces2, las1)
     # 4. Spin excitations part 2
     if nspin:
-        las3 = spin_flip_products (las2, spin_flips, nroots_ref=nroots_ref)
+        spaces3 = spin_flip_products (las1, spaces2, spin_flips, nroots_ref=nroots_ref)
     else:
-        las3 = las2
+        spaces3 = spaces2
+    weights = [space.weight for space in spaces3]
+    charges = [space.charges for space in spaces3]
+    spins = [space.spins for space in spaces3]
+    smults = [space.smults for space in spaces3]
+    ci3 = [[space.ci[ifrag] for space in spaces3] for ifrag in range (lsi.nfrags)]
+    las3 = las1.state_average (weights=weights, charges=charges, spins=spins, smults=smults, assert_no_dupes=False)
+    las3.ci = ci3
     las3.lasci (_dry_run=True)
+    log.timer ("LASSIS model space preparation", *t0)
     return converged, las3
 
 def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_vrv=False,
@@ -75,8 +89,7 @@ def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_
     mol = lsi.mol
     nfrags = lsi.nfrags
     e_roots = np.append (las1.e_states, np.zeros (las2.nroots-las1.nroots))
-    ci = [[ci_ij for ci_ij in ci_i] for ci_i in las2.ci]
-    spaces = [SingleLASRootspace (las2, m, s, c, las2.weights[ix], ci=[c[ix] for c in ci])
+    spaces = [SingleLASRootspace (las2, m, s, c, las2.weights[ix], ci=[c[ix] for c in las2.ci])
               for ix, (c, m, s, w) in enumerate (zip (*get_space_info (las2)))]
     ncsf = las2.get_ugg ().ncsf_sub
     auto_singles = False
@@ -92,24 +105,14 @@ def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_
     h0, h1, h2 = lsi.ham_2q ()
     t0 = (logger.process_clock (), logger.perf_counter ())
     converged = True
-    log.info ("LASSIS electron hop spaces: %d-%d", las1.nroots, las2.nroots-1)
-    for i in range (las1.nroots, las2.nroots):
-        # spin shuffle escape
-        i_ssref = None
-        for i0 in range (las1.nroots, i):
-            if spaces[i].is_spin_shuffle_of (spaces[i0]):
-                i_ssref = i0
-                break
-        if i_ssref is not None:
-            spaces[i].ci = spaces[i].get_spin_shuffle_civecs (spaces[i_ssref])
-            log.info ("Electron hop space %d:", i)
-            spaces[i].table_printlog ()
-            log.info ("is a spin shuffle of space %d", i_ssref)
-            for k in range (nfrags):
-                ci[k][i] = spaces[i].ci[k]
-            t0 = log.timer ("Space {} excitations".format (i), *t0)
-            continue
-        # end spin shuffle escape
+    # Prefilter spin-shuffles
+    spaces = [spi for i, spi in enumerate (spaces)
+              if (i<las1.nroots) or not any (
+                [spi.is_spin_shuffle_of (spj) for spj in spaces[:i]]
+              )]
+    log.info ("LASSIS electron hop spaces: %d-%d", las1.nroots, len (spaces)-1)
+    for i in range (las1.nroots, len (spaces)):
+        # compute lroots
         psref_ix = [j for j, space in enumerate (spaces[:las1.nroots])
                     if spaces[i].is_single_excitation_of (space)]
         psref = [spaces[j] for j in psref_ix]
@@ -121,7 +124,8 @@ def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_
         psref = [space for space in psref if spaces[i].is_single_excitation_of (space)]
         if auto_singles:
             lr = spaces[i].compute_single_excitation_lroots (psref)
-            lroots[:,i] = np.minimum (lroots[:,i], lr)
+            lroots[:,i][excfrags] = np.minimum (lroots[:,i][excfrags], lr)
+        lroots[:,i][~excfrags] = 1
         # logging after setup
         log.info ("Electron hop space %d:", i)
         spaces[i].table_printlog (lroots=lroots[:,i])
@@ -137,6 +141,7 @@ def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_
         ciref = [[] for j in range (nfrags)]
         for k in range (nfrags):
             for space in psref: ciref[k].append (space.ci[k])
+        spaces[i].set_entmap_(psref[0])
         psref = [space.get_product_state_solver () for space in psref]
         psexc = ExcitationPSFCISolver (psref, ciref, las2.ncas_sub, las2.nelecas_sub,
                                        stdout=mol.stdout, verbose=mol.verbose,
@@ -167,10 +172,8 @@ def single_excitations_ci (lsi, las2, las1, ncharge=1, sa_heff=True, deactivate_
         spaces[i].ci = ci1
         if not conv: log.warn ("CI vectors for charge-separated rootspace %d not converged", i)
         converged = converged and conv
-        for k in range (nfrags):
-            ci[k][i] = ci1[k]
         t0 = log.timer ("Space {} excitations".format (i), *t0)
-    return converged, ci, e_roots
+    return converged, spaces
 
 class SpinFlips (object):
     '''For a single fragment, bundle the ci vectors of various spin-flipped states with their
@@ -300,37 +303,105 @@ def _spin_flip_products (spaces, spin_flips, nroots_ref=1, frozen_frags=None):
     spaces = [space for space in spaces if not ((space in seen) or seen.add (space))]
     return spaces
 
-def spin_flip_products (las2, spin_flips, nroots_ref=1):
+def _spin_shuffle_ci_(spaces, spin_flips, nroots_ref, nroots_refc):
+    '''Memory-efficient version of the function spaces._spin_shuffle_ci_.
+    Based on the fact that we know there has only been one independent set
+    of vectors per fragment Hilbert space and that all possible individual
+    fragment spins must be accounted for already, so we are just recombining
+    them.'''
+    old_idx = []
+    new_idx = []
+    nfrag = spaces[0].nfrag
+    for ix, space in enumerate (spaces):
+        if space.has_ci ():
+            old_idx.append (ix)
+        else:
+            assert (ix >= nroots_refc)
+            new_idx.append (ix)
+            space.ci = [None for ifrag in range (space.nfrag)]
+    # Prepare charge-hop szrots
+    spaces_1c = spaces[nroots_ref:nroots_refc]
+    spaces_1c = [space for space in spaces_1c if len (space.entmap)==1]
+    ci_szrot_1c = []
+    for ix, space in enumerate (spaces_1c):
+        ifrag, jfrag = space.entmap[0] # must be a tuple of length 2
+        ci_szrot_1c.append (space.get_ci_szrot (ifrags=(ifrag,jfrag)))
+    charges0 = spaces[0].charges
+    smults0 = spaces[0].smults
+    for ix in new_idx:
+        idx = spaces[ix].excited_fragments (spaces[0])
+        space = spaces[ix]
+        for ifrag in np.where (~idx)[0]:
+            space.ci[ifrag] = spaces[0].ci[ifrag]
+        for ifrag in np.where (idx)[0]:
+            if space.charges[ifrag] != charges0[ifrag]: continue
+            if space.smults[ifrag] != smults0[ifrag]:
+                sf = spin_flips[ifrag]
+                iflp = sf.smults == space.smults[ifrag]
+                iflp &= sf.spins == space.spins[ifrag]
+                assert (np.count_nonzero (iflp) == 1)
+                iflp = np.where (iflp)[0][0]
+                space.ci[ifrag] = sf.ci[iflp]
+            else: # Reference-state spin-shuffles
+                spaces0 = [sp for sp in spaces[:nroots_ref] if sp.spins[ifrag]==space.spins[ifrag]]
+                assert (len (spaces0))
+                space.ci[ifrag] = spaces0[0].ci[ifrag]
+        for (ci_i, ci_j), sp_1c in zip (ci_szrot_1c, spaces_1c):
+            ijfrag = sp_1c.entmap[0]
+            if ijfrag not in spaces[ix].entmap: continue
+            if np.any (sp_1c.charges[list(ijfrag)] != space.charges[list(ijfrag)]): continue
+            if np.any (sp_1c.smults[list(ijfrag)] != space.smults[list(ijfrag)]): continue
+            ifrag, jfrag = ijfrag
+            assert (space.ci[ifrag] is None)
+            assert (space.ci[jfrag] is None)
+            space.ci[ifrag] = ci_i[space.spins[ifrag]]
+            space.ci[jfrag] = ci_j[space.spins[jfrag]]
+        assert (space.has_ci ())
+    return spaces
+
+def spin_flip_products (las, spaces, spin_flips, nroots_ref=1):
     '''Inject spin-flips into las2 in all possible ways'''
-    log = logger.new_logger (las2, las2.verbose)
-    spaces = [SingleLASRootspace (las2, m, s, c, las2.weights[ix], ci=[c[ix] for c in las2.ci])
-              for ix, (c, m, s, w) in enumerate (zip (*get_space_info (las2)))]
+    log = logger.new_logger (las, las.verbose)
+    las2_nroots = len (spaces)
     spaces = _spin_flip_products (spaces, spin_flips, nroots_ref=nroots_ref)
     nfrags = spaces[0].nfrag
-    weights = [space.weight for space in spaces]
-    charges = [space.charges for space in spaces]
-    spins = [space.spins for space in spaces]
-    smults = [space.smults for space in spaces]
-    ci3 = [[space.ci[ifrag] for space in spaces] for ifrag in range (nfrags)]
-    las3 = las2.state_average (weights=weights, charges=charges, spins=spins, smults=smults)
-    las3.ci = ci3
-    if las3.nfrags > 2: # A second spin shuffle to get the coupled spin-charge excitations
-        las3 = spin_shuffle (las3)
-        las3.ci = spin_shuffle_ci (las3, las3.ci)
-    spaces = [SingleLASRootspace (las3, m, s, c, las3.weights[ix], ci=[c[ix] for c in las3.ci])
-              for ix, (c, m, s, w) in enumerate (zip (*get_space_info (las3)))]
-    log.info ("LASSIS spin-excitation spaces: %d-%d", las2.nroots, las3.nroots-1)
-    for i, space in enumerate (spaces[las2.nroots:]):
+    spaces = _spin_shuffle (spaces)
+    spaces = _spin_shuffle_ci_(spaces, spin_flips, nroots_ref, las2_nroots)
+    log.info ("LASSIS spin-excitation spaces: %d-%d", las2_nroots, len (spaces)-1)
+    for i, space in enumerate (spaces[las2_nroots:]):
         if np.any (space.nelec != spaces[0].nelec):
-            log.info ("Spin/charge-excitation space %d:", i+las2.nroots)
+            log.info ("Spin/charge-excitation space %d:", i+las2_nroots)
         else:
-            log.info ("Spin-excitation space %d:", i+las2.nroots)
+            log.info ("Spin-excitation space %d:", i+las2_nroots)
         space.table_printlog ()
-    return las3
+    return spaces
 
-def charge_excitation_products (las2, las1):
-    # TODO: direct product of single-electron hops
-    raise NotImplementedError (">3-frag LASSIS")
+def charge_excitation_products (lsi, spaces, las1):
+    t0 = (logger.process_clock (), logger.perf_counter ())
+    log = logger.new_logger (lsi, lsi.verbose)
+    mol = lsi.mol
+    nfrags = lsi.nfrags
+    space0 = spaces[0]
+    i0, j0 = i, j = las1.nroots, len (spaces)
+    for product_order in range (2, (nfrags//2)+1):
+        seen = set ()
+        for i_list in itertools.combinations (range (i,j), product_order):
+            p_list = [spaces[ip] for ip in i_list]
+            nonorth = False
+            for p, q in itertools.combinations (p_list, 2):
+                if not orthogonal_excitations (p, q, space0):
+                    nonorth = True
+                    break
+            if nonorth: continue
+            p = p_list[0]
+            for q in p_list[1:]:
+                p = combine_orthogonal_excitations (p, q, space0)
+            spaces.append (p)
+            log.info ("Electron hop product space %d (product of %s)", len (spaces) - 1, str (i_list))
+            spaces[-1].table_printlog ()
+    assert (len (spaces) == len (set (spaces)))
+    log.timer ("LASSIS charge-hop product generation", *t0)
+    return spaces
 
 def as_scanner(lsi):
     '''Generating a scanner for LASSIS PES.
@@ -382,6 +453,18 @@ class LASSIS_Scanner(lib.SinglePointScanner):
 class LASSIS (LASSI):
     def __init__(self, las, ncharge='s', nspin='s', sa_heff=True, deactivate_vrv=False,
                  crash_locmin=False, opt=1, **kwargs):
+        '''
+        Key attributes:
+            _las : instance of class `LASCINoSymm`
+                The encapsulated LASSCF wave function. The CI vectors of the reference state are,
+                i.e., _las.get_single_state_las (state=0).ci.
+            ci_spin_flips : dict
+                Keys are (i,s) with integer i and string s = 'u' or 'd'. Values are the spin-up
+                (s='u') or spin-down (s='d') CI vectors of the ith fragment.
+            ci_charge_hops: dict
+                Keys are hash strings for particular charge-hop rootspaces, and values are the CI
+                vectors of the involved fragments.
+        '''
         self.ncharge = ncharge
         self.nspin = nspin
         self.sa_heff = sa_heff
@@ -399,14 +482,26 @@ class LASSIS (LASSI):
 
     def kernel (self, ncharge=None, nspin=None, sa_heff=None, deactivate_vrv=None,
                 crash_locmin=None, **kwargs):
+        t0 = (logger.process_clock (), logger.perf_counter ())
+        log = logger.new_logger (self, self.verbose)
+        self.converged = self.prepare_states_(ncharge=ncharge, nspin=nspin,
+                                              sa_heff=sa_heff, deactivate_vrv=deactivate_vrv,
+                                              crash_locmin=crash_locmin)
+        self.e_roots, self.si = self.eig (**kwargs)
+        log.timer ("LASSIS", *t0)
+        return self.e_roots, self.si
+
+    def prepare_states_(self, ncharge=None, nspin=None, sa_heff=None, deactivate_vrv=None,
+                        crash_locmin=None, **kwargs):
         if ncharge is None: ncharge = self.ncharge
         if nspin is None: nspin = self.nspin
         if sa_heff is None: sa_heff = self.sa_heff
         if deactivate_vrv is None: deactivate_vrv = self.deactivate_vrv
         if crash_locmin is None: crash_locmin = self.crash_locmin
-        self.converged, las = prepare_states (self, ncharge=ncharge, nspin=nspin,
-                                              sa_heff=sa_heff, deactivate_vrv=deactivate_vrv,
-                                              crash_locmin=crash_locmin)
+        log = logger.new_logger (self, self.verbose)
+        self.converged, las = self.prepare_states (ncharge=ncharge, nspin=nspin,
+                                                   sa_heff=sa_heff, deactivate_vrv=deactivate_vrv,
+                                                   crash_locmin=crash_locmin)
         #self.__dict__.update(las.__dict__) # Unsafe
         self.fciboxes = las.fciboxes
         self.ci = las.ci
@@ -414,7 +509,11 @@ class LASSIS (LASSI):
         self.weights = las.weights
         self.e_lexc = las.e_lexc
         self.e_states = las.e_states
-        return LASSI.kernel (self, **kwargs)
+        log.info ('LASSIS model state summary: %d rootspaces; %d model states; converged? %s',
+                  self.nroots, self.get_lroots ().prod (0).sum (), str (self.converged))
+        return self.converged
 
+    eig = LASSI.kernel
     as_scanner = as_scanner
+    prepare_states = prepare_states
 

--- a/my_pyscf/lassi/op_o1.py
+++ b/my_pyscf/lassi/op_o1.py
@@ -1,10 +1,12 @@
 import numpy as np
+from scipy import linalg
 from pyscf import lib, fci
+from pyscf.lib import logger
 from pyscf.fci.direct_spin1 import _unpack_nelec, trans_rdm12s, contract_1e
 from pyscf.fci.addons import cre_a, cre_b, des_a, des_b
 from pyscf.fci import cistring
-from itertools import product, combinations
-from mrh.my_pyscf.lassi.citools import get_lroots, get_rootaddr_fragaddr
+from itertools import product, combinations, combinations_with_replacement
+from mrh.my_pyscf.lassi.citools import get_lroots, get_rootaddr_fragaddr, umat_dot_1frag_
 import time
 
 # NOTE: PySCF has a strange convention where
@@ -202,10 +204,13 @@ class LSTDMint1 (object):
         Kwargs:
             dtype : instance of np.dtype
                 Currently not used
+            screen_linequiv : logical
+                Whether to compress data by aggressively identifying linearly equivalent
+                rootspaces and storing the relevant unitary matrices.
     '''
 
     def __init__(self, ci, hopping_index, zerop_index, onep_index, norb, nroots, nelec_rs,
-                 rootaddr, fragaddr, idx_frag, dtype=np.float64):
+                 rootaddr, fragaddr, idx_frag, dtype=np.float64, screen_linequiv=True):
         # TODO: if it actually helps, cache the "linkstr" arrays
         self.ci = ci
         self.hopping_index = hopping_index
@@ -227,11 +232,11 @@ class LSTDMint1 (object):
         self.idx_frag = idx_frag
 
         # Consistent array shape
-        self.ndeta_r = [cistring.num_strings (norb, nelec[0]) for nelec in self.nelec_r]
-        self.ndetb_r = [cistring.num_strings (norb, nelec[1]) for nelec in self.nelec_r]
+        self.ndeta_r = np.array ([cistring.num_strings (norb, nelec[0]) for nelec in self.nelec_r])
+        self.ndetb_r = np.array ([cistring.num_strings (norb, nelec[1]) for nelec in self.nelec_r])
         self.ci = [c.reshape (-1,na,nb) for c, na, nb in zip (self.ci, self.ndeta_r, self.ndetb_r)]
 
-        self.time_crunch = self._init_crunch_()
+        self.time_crunch = self._init_crunch_(screen_linequiv)
 
     # Exception catching
 
@@ -241,7 +246,7 @@ class LSTDMint1 (object):
         else: raise RuntimeError (str (len (args)))
 
     def try_get_dm (self, tab, i, j):
-        ir, jr = self.rootaddr[i], self.rootaddr[j]
+        ir, jr = self.unique_root[self.rootaddr[i]], self.unique_root[self.rootaddr[j]]
         try:
             assert (tab[ir][jr] is not None)
             ip, jp = self.fragaddr[i], self.fragaddr[j]
@@ -252,7 +257,7 @@ class LSTDMint1 (object):
             raise RuntimeError (errstr)
 
     def try_get_tdm (self, tab, s, i, j):
-        ir, jr = self.rootaddr[i], self.rootaddr[j]
+        ir, jr = self.unique_root[self.rootaddr[i]], self.unique_root[self.rootaddr[j]]
         try:
             assert (tab[s][ir][jr] is not None)
             ip, jp = self.fragaddr[i], self.fragaddr[j]
@@ -320,7 +325,7 @@ class LSTDMint1 (object):
     # 1-density intermediate
 
     def get_dm1 (self, i, j):
-        if j > i:
+        if self.unique_root[self.rootaddr[j]] > self.unique_root[self.rootaddr[i]]:
             return self.try_get (self.dm1, j, i).conj ().transpose (0, 2, 1)
         return self.try_get (self.dm1, i, j)
 
@@ -333,7 +338,7 @@ class LSTDMint1 (object):
     # 2-density intermediate
 
     def get_dm2 (self, i, j):
-        if j > i:
+        if self.unique_root[self.rootaddr[j]] > self.unique_root[self.rootaddr[i]]:
             return self.try_get (self.dm2, j, i).conj ().transpose (0, 2, 1, 4, 3)
         return self.try_get (self.dm2, i, j)
 
@@ -344,7 +349,7 @@ class LSTDMint1 (object):
         else:
             self.dm2[i][j] = x
 
-    def _init_crunch_(self):
+    def _init_crunch_(self, screen_linequiv):
         ''' Compute the transition density matrix factors.
 
         Returns:
@@ -362,17 +367,60 @@ class LSTDMint1 (object):
 
         lroots = [c.shape[0] for c in ci]
 
+        # index down to only the unique rootspaces
+        self.root_unique = np.ones (self.nroots, dtype=bool)
+        self.unique_root = np.arange (self.nroots, dtype=int)
+        self.umat_root = {}
+        for i, j in combinations (range (self.nroots), 2):
+            if not self.root_unique[i]: continue
+            if not self.root_unique[j]: continue
+            if self.nelec_r[i] != self.nelec_r[j]: continue
+            if lroots[i] != lroots[j]: continue
+            if ci[i].shape != ci[j].shape: continue
+            isequal = False
+            if ci[i] is ci[j]: isequal = True
+            elif np.all (ci[i]==ci[j]): isequal = True
+            elif np.all (np.abs (ci[i]-ci[j]) < 1e-8): isequal=True
+            else:
+                ci_i = ci[i].reshape (lroots[i],-1)
+                ci_j = ci[j].reshape (lroots[j],-1)
+                ovlp = ci_i.conj () @ ci_j.T
+                isequal = np.allclose (ovlp.diagonal (), 1,
+                                       rtol=1e-10, atol=1e-10)
+                                       # need extremely high precision on this one
+                if screen_linequiv and (not isequal):
+                    u, svals, vh = linalg.svd (ovlp)
+                    assert (len (svals) == lroots[i])
+                    isequal = np.allclose (svals, 1, rtol=1e-8, atol=1e-8)
+                    if isequal: self.umat_root[j] = u @ vh
+            if isequal:
+                self.root_unique[j] = False
+                self.unique_root[j] = i
+                self.onep_index[i] |= self.onep_index[j]
+                self.onep_index[:,i] |= self.onep_index[:,j]
+                self.zerop_index[i] |= self.zerop_index[j]
+                self.zerop_index[:,i] |= self.zerop_index[:,j]
+        for i in range (self.nroots):
+            assert (self.root_unique[self.unique_root[i]])
+        idx_uniq = self.root_unique
+
         # Overlap matrix
         offs = np.cumsum (lroots)
-        for i, j in combinations (range (self.nroots), 2):
+        for i, j in combinations (np.where (idx_uniq)[0], 2):
             if self.nelec_r[i] == self.nelec_r[j]:
                 ci_i = ci[i].reshape (lroots[i], -1)
                 ci_j = ci[j].reshape (lroots[j], -1)
                 self.ovlp[i][j] = np.dot (ci_i.conj (), ci_j.T)
                 self.ovlp[j][i] = self.ovlp[i][j].conj ().T
-        for i in range (self.nroots):
+        for i in np.where (idx_uniq)[0]:
             ci_i = ci[i].reshape (lroots[i], -1)
             self.ovlp[i][i] = np.dot (ci_i.conj (), ci_i.T)
+            errmat = self.ovlp[i][i] - np.eye (lroots[i])
+            if np.amax (np.abs (errmat)) > 1e-3:
+                w, v = np.linalg.eigh (self.ovlp[i][i])
+                errmsg = ('States w/in single Hilbert space must be orthonormal; '
+                          'eigvals (ovlp) = {}')
+                raise RuntimeError (errmsg.format (w))
 
         # Loop over lroots functions
         def des_loop (des_fn, c, nelec, p):
@@ -400,7 +448,9 @@ class LSTDMint1 (object):
 
         # Spectator fragment contribution
         spectator_index = np.all (hopping_index == 0, axis=0)
-        spectator_index[np.triu_indices (self.nroots, k=1)] = False
+        spectator_index[~idx_uniq,:] = False
+        spectator_index[:,~idx_uniq] = False
+        spectator_index[np.triu_indices (nroots, k=1)] = False
         spectator_index = np.stack (np.where (spectator_index), axis=1)
         for i, j in spectator_index:
             dm1s, dm2s = trans_rdm12s_loop (j, ci[i], ci[j])
@@ -409,8 +459,8 @@ class LSTDMint1 (object):
 
         # Cache some b_p|i> beforehand for the sake of the spin-flip intermediate 
         # shape = (norb, lroots[ket], ndeta[ket], ndetb[*])
-        hidx_ket_a = np.where (np.any (hopping_index[0] < 0, axis=0))[0]
-        hidx_ket_b = np.where (np.any (hopping_index[1] < 0, axis=0))[0]
+        hidx_ket_a = np.where (np.any (hopping_index[0] < 0, axis=0) & idx_uniq)[0]
+        hidx_ket_b = np.where (np.any (hopping_index[1] < 0, axis=0) & idx_uniq)[0]
         bpvec_list = [None for ket in range (nroots)]
         for ket in hidx_ket_b:
             if np.any (np.all (hopping_index[:,:,ket] == np.array ([1,-1])[:,None], axis=0)):
@@ -422,7 +472,7 @@ class LSTDMint1 (object):
             nelec = self.nelec_r[ket]
             apket = np.stack ([des_a_loop (ci[ket], nelec, p) for p in range (norb)], axis=0)
             nelec = (nelec[0]-1, nelec[1])
-            for bra in np.where (hopping_index[0,:,ket] < 0)[0]:
+            for bra in np.where ((hopping_index[0,:,ket] < 0) & idx_uniq)[0]:
                 bravec = ci[bra].reshape (lroots[bra], ndeta[bra]*ndetb[bra]).conj ()
                 # <j|a_p|i>
                 if np.all (hopping_index[:,bra,ket] == [-1,0]):
@@ -468,7 +518,7 @@ class LSTDMint1 (object):
             bpket = np.stack ([des_b_loop (ci[ket], nelec, p)
                 for p in range (norb)], axis=0) if bpvec_list[ket] is None else bpvec_list[ket]
             nelec = (nelec[0], nelec[1]-1)
-            for bra in np.where (hopping_index[1,:,ket] < 0)[0]:
+            for bra in np.where ((hopping_index[1,:,ket] < 0) & idx_uniq)[0]:
                 bravec = ci[bra].reshape (lroots[bra], ndeta[bra]*ndetb[bra]).conj ()
                 # <j|b_p|i>
                 if np.all (hopping_index[:,bra,ket] == [0,-1]):
@@ -599,17 +649,23 @@ class LSTDMint2 (object):
     # TODO: at some point, if it ever becomes rate-limiting, make this multithread better
 
     def __init__(self, ints, nlas, hopping_index, lroots, mask_bra_space=None, mask_ket_space=None,
-                 dtype=np.float64):
+                 log=None, dtype=np.float64):
         self.ints = ints
+        self.log = log
         self.nlas = nlas
         self.norb = sum (nlas)
         self.lroots = lroots
-        self.rootaddr = get_rootaddr_fragaddr (lroots)[0]
+        self.rootaddr, self.envaddr = get_rootaddr_fragaddr (lroots)
+        self.envaddr = np.ascontiguousarray (self.envaddr.T)
         nprods = np.prod (lroots, axis=0)
         offs1 = np.cumsum (nprods)
         offs0 = offs1 - nprods
         self.offs_lroots = np.stack ([offs0, offs1], axis=1)
         self.nfrags, _, self.nroots, _ = hopping_index.shape
+        self.strides = np.append (np.ones (self.nroots, dtype=int)[None,:],
+                                  np.cumprod (lroots[:-1,:], axis=0),
+                                  axis=0).T
+        self.strides = np.ascontiguousarray (self.strides)
         self.nstates = offs1[-1]
         self.dtype = dtype
         self.tdm1s = self.tdm2s = None
@@ -625,11 +681,32 @@ class LSTDMint2 (object):
         self.nelec_rf = self.nelec_rf.sum (1)
 
         exc = self.make_exc_tables (hopping_index)
-        self.exc_null = self.mask_exc_table (exc['null'], mask_bra_space, mask_ket_space)
-        self.exc_1c = self.mask_exc_table (exc['1c'], mask_bra_space, mask_ket_space)
-        self.exc_1s = self.mask_exc_table (exc['1s'], mask_bra_space, mask_ket_space)
-        self.exc_1s1c = self.mask_exc_table (exc['1s1c'], mask_bra_space, mask_ket_space)
-        self.exc_2c = self.mask_exc_table (exc['2c'], mask_bra_space, mask_ket_space)
+        self.nonuniq_exc = {}
+        self.exc_null = self.mask_exc_table_(exc['null'], 'null', mask_bra_space, mask_ket_space)
+        self.exc_1d = self.mask_exc_table_(exc['1d'], '1d', mask_bra_space, mask_ket_space)
+        self.exc_2d = self.mask_exc_table_(exc['2d'], '2d', mask_bra_space, mask_ket_space)
+        self.exc_1c = self.mask_exc_table_(exc['1c'], '1c', mask_bra_space, mask_ket_space)
+        self.exc_1c1d = self.mask_exc_table_(exc['1c1d'], '1c1d', mask_bra_space, mask_ket_space)
+        self.exc_1s = self.mask_exc_table_(exc['1s'], '1s', mask_bra_space, mask_ket_space)
+        self.exc_1s1c = self.mask_exc_table_(exc['1s1c'], '1s1c', mask_bra_space, mask_ket_space)
+        self.exc_2c = self.mask_exc_table_(exc['2c'], '2c', mask_bra_space, mask_ket_space)
+        self.init_profiling ()
+
+        # buffer
+        self.d1 = np.zeros ([2,]+[self.norb,]*2, dtype=self.dtype)
+        self.d2 = np.zeros ([4,]+[self.norb,]*4, dtype=self.dtype)
+
+    def init_profiling (self):
+        self.dt_1d, self.dw_1d = 0.0, 0.0
+        self.dt_2d, self.dw_2d = 0.0, 0.0
+        self.dt_1c, self.dw_1c = 0.0, 0.0
+        self.dt_1c1d, self.dw_1c1d = 0.0, 0.0
+        self.dt_1s, self.dw_1s = 0.0, 0.0
+        self.dt_1s1c, self.dw_1s1c = 0.0, 0.0
+        self.dt_2c, self.dw_2c = 0.0, 0.0
+        self.dt_o, self.dw_o = 0.0, 0.0
+        self.dt_u, self.dw_u = 0.0, 0.0
+        self.dt_p, self.dw_p = 0.0, 0.0
 
     def make_exc_tables (self, hopping_index):
         ''' Generate excitation tables. The nth column of each array is the (n+1)th argument of the
@@ -646,11 +723,14 @@ class LSTDMint2 (object):
         Returns:
             exc: dict with str keys and ndarray-of-int values. Each row of each ndarray is the
                 argument list for 1 call to the LSTDMint2._crunch_*_ function with the name that
-                corresponds to the key str (_crunch_null_, _crunch_1s_, etc.).
+                corresponds to the key str (_crunch_1d_, _crunch_1s_, etc.).
         '''
         exc = {}
         exc['null'] = np.empty ((0,2), dtype=int)
+        exc['1d'] = np.empty ((0,3), dtype=int)
+        exc['2d'] = np.empty ((0,4), dtype=int)
         exc['1c'] = np.empty ((0,5), dtype=int)
+        exc['1c1d'] = np.empty ((0,6), dtype=int)
         exc['1s'] = np.empty ((0,4), dtype=int)
         exc['1s1c'] = np.empty ((0,5), dtype=int)
         exc['2c'] = np.empty ((0,7), dtype=int)
@@ -696,15 +776,38 @@ class LSTDMint2 (object):
 
         # Zero-electron interactions
         tril_index = np.zeros_like (conserv_index)
-        tril_index[np.tril_indices (self.nroots,k=-1)] = True
+        tril_index[np.tril_indices (self.nroots)] = True
         idx = conserv_index & tril_index & (nop == 0)
         exc['null'] = np.vstack (list (np.where (idx))).T
  
+        # One-density interactions
+        fragrng = np.arange (nfrags, dtype=int)
+        exc['1d'] = np.append (np.repeat (exc['null'], nfrags, axis=0),
+                               np.tile (fragrng, len (exc['null']))[:,None],
+                               axis=1)
+
+        # Two-density interactions
+        if nfrags > 1:
+            fragrng = np.stack (np.tril_indices (nfrags, k=-1), axis=1)
+            exc['2d'] = np.append (np.repeat (exc['null'], len (fragrng), axis=0),
+                                   np.tile (fragrng, (len (exc['null']), 1)),
+                                   axis=1)
+
         # One-electron interactions
         idx = conserv_index & (nop == 2) & tril_index
         if nfrags > 1: exc['1c'] = np.vstack (
             list (np.where (idx)) + [findf[-1][idx], findf[0][idx], ispin[idx]]
         ).T
+
+        # One-electron, one-density interactions
+        if nfrags > 2:
+            fragrng = np.arange (nfrags, dtype=int)
+            exc['1c1d'] = np.append (np.repeat (exc['1c'], nfrags, axis=0),
+                                     np.tile (fragrng, len (exc['1c']))[:,None],
+                                     axis=1)
+            invalid = ((exc['1c1d'][:,2] == exc['1c1d'][:,5])
+                       | (exc['1c1d'][:,3] == exc['1c1d'][:,5]))
+            exc['1c1d'] = exc['1c1d'][~invalid,:][:,[0,1,2,3,5,4]]
 
         # Unsymmetric two-electron interactions: full square
         idx_2e = conserv_index & (nop == 4)
@@ -752,18 +855,75 @@ class LSTDMint2 (object):
 
         return exc
 
-    def mask_exc_table (self, exc, mask_bra_space=None, mask_ket_space=None):
-        # TODO: PROBLEM: this transposes "bra" and "ket"
+    def mask_exc_table_(self, exc, lbl, mask_bra_space=None, mask_ket_space=None):
+        # Part 1: restrict to the caller-specified rectangle
         exc = mask_exc_table (exc, col=0, mask_space=mask_bra_space)
         exc = mask_exc_table (exc, col=1, mask_space=mask_ket_space)
+        # Part 2: identify interactions which are equivalent except for the overlap
+        # factor of spectator fragments. Reduce the exc table only to the unique
+        # interactions and populate self.nonuniq_exc with the corresponding
+        # nonunique images.
+        if lbl=='null': return exc
+        excp = exc[:,:-1] if lbl in ('1c', '1c1d', '2c') else exc
+        fprint = []
+        for row in excp:
+            frow = []
+            bra, ket = row[:2]
+            frags = row[2:]
+            for frag in frags:
+                intf = self.ints[frag]
+                frow.extend ([frag, intf.unique_root[bra], intf.unique_root[ket]])
+            fprint.append (frow)
+        fprint = np.asarray (fprint)
+        nexc = len (exc)
+        _, idx, inv = np.unique (fprint, axis=0, return_index=True, return_inverse=True)
+        eqmap = idx[inv]
+        for uniq_idx in idx:
+            row_uniq = excp[uniq_idx]
+            braket_images = exc[:,:2][eqmap==uniq_idx]
+            self.nonuniq_exc[tuple(row_uniq)] = braket_images
+        exc = exc[idx]
+        nuniq = len (idx)
+        self.log.debug ('%d/%d unique interactions of %s type',
+                        nuniq, nexc, lbl)
         return exc
 
     def get_range (self, i):
+        '''Get the orbital range for a fragment.
+
+        Args:
+            i: integer
+                index of a fragment
+
+        Returns:
+            p: integer
+                beginning of ith fragment orbital range
+            q: integer
+                end of ith fragment orbital range
+        '''
         p = sum (self.nlas[:i])
         q = p + self.nlas[i]
         return p, q
 
     def get_ovlp_fac (self, bra, ket, *inv):
+        '''Compute the overlap * permutation factor between two model states for a given list of
+        non-spectator fragments.
+
+        Args:
+            bra: integer
+                Index of a model state
+            ket: integer
+                Index of a model state
+            *inv: integers
+                Indices of nonspectator fragments
+
+        Returns:
+            wgt: float
+                The product of the overlap matrix elements between bra and ket for all fragments
+                not included in *inv, multiplied by the fermion permutation factor required to
+                bring the field operators of those in *inv adjacent to each other in normal
+                order.
+        '''
         idx = np.ones (self.nfrags, dtype=np.bool_)
         idx[list (inv)] = False
         wgt = np.prod ([i.get_ovlp (bra, ket) for i, ix in zip (self.ints, idx) if ix])
@@ -774,48 +934,205 @@ class LSTDMint2 (object):
         wgt *= fermion_frag_shuffle (self.nelec_rf[ket], uniq_frags)
         return wgt
 
-    def _get_D1_(self, bra, ket):
-        return self.tdm1s[bra,ket]
+    def _get_addr_range (self, raddr, *inv):
+        '''Get the integer offsets for successive ENVs in a particular rootspace in which some
+        fragments are frozen in the zero state.
 
-    def _put_D1_(self, bra, ket, D1):
-        pass
+        Args:
+            raddr: integer
+                Index of a rootspace
+            *inv: integers
+                Indicies of fragments to be included in the iteration. All other fragments are
+                frozen in the zero state.
+
+        Returns
+            addrs: ndarray of integers
+                Indices of states with different excitation numbers in the fragments in *inv, with
+                all other fragments frozen in the zero state.
+        '''
+        addr0, addr1 = self.offs_lroots[raddr]
+        inv = list (set (inv))
+        lroots = self.lroots[:,raddr:raddr+1]
+        envaddr_inv = get_rootaddr_fragaddr (lroots[inv])[1]
+        strides_inv = self.strides[raddr][inv]
+        return addr0 + np.dot (strides_inv, envaddr_inv)
+
+    def _prepare_spec_addr_ovlp_(self, rbra, rket, *inv):
+        '''Prepare the cache for _get_spec_addr_ovlp.
+
+        Args:
+            rbra: integer
+                Index of bra rootspace for which to prepare the current cache.
+            rket: integer
+                Index of ket rootspace for which to prepare the current cache.
+            *inv: integers
+                Indices of nonspectator fragments
+        '''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        key = tuple ((rbra,rket)) + inv
+        braket_table = self.nonuniq_exc[key]
+        self._spec_addr_ovlp_cache = []
+        for rbra1, rket1 in braket_table:
+            b, k, o = self._get_spec_addr_ovlp_1space (rbra1, rket1, *inv)
+            self._spec_addr_ovlp_cache.append ((rbra1, rket1, b, k, o))
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_o, self.dw_o = self.dt_o + dt, self.dw_o + dw
+        return
+
+    def _get_spec_addr_ovlp (self, bra, ket, *inv):
+        '''Obtain the integer indices and overlap*permutation factors for all pairs of model states
+        for which a specified list of nonspectator fragments are in same state that they are in a
+        provided input pair bra, ket. Uses a cache that must be prepared beforehand by the function
+        _prepare_spec_addr_ovlp_(rbra, rket, *inv), where rbra and rket must be the rootspace
+        indices corresponding to this function's bra, ket arguments.
+
+        Args:
+            bra: integer
+                Index of a model state
+            ket: integer
+                Index of a model state
+            *inv: integers
+                Indices of nonspectator fragments.
+
+        Returns:
+            bra_rng: ndarray of integers
+                Indices of model states in which fragments *inv have the same state as bra
+            ket_rng: ndarray of integers
+                Indices of model states in which fragments *inv have the same state as ket
+            facs: ndarray of floats
+                Overlap * permutation factors (cf. get_ovlp_fac) corresponding to the interactions
+                bra_rng, ket_rng.
+        '''
+        rbra, rket = self.rootaddr[bra], self.rootaddr[ket]
+        braenv = self.envaddr[bra]
+        ketenv = self.envaddr[ket]
+        key = tuple ((rbra,rket)) + inv
+        braket_table = self.nonuniq_exc[key]
+        bra_rng = []
+        ket_rng = []
+        facs = []
+        for (rbra1, rket1, b, k, o) in self._spec_addr_ovlp_cache:
+            dbra = np.dot (braenv, self.strides[rbra1])
+            dket = np.dot (ketenv, self.strides[rket1])
+            bra_rng.append (b+dbra)
+            ket_rng.append (k+dket)
+            facs.append (o)
+        bra_rng = np.concatenate (bra_rng)
+        ket_rng = np.concatenate (ket_rng)
+        facs = np.concatenate (facs)
+        return bra_rng, ket_rng, facs
+
+    def _get_spec_addr_ovlp_1space (self, rbra, rket, *inv):
+        '''Obtain the integer indices and overlap*permutation factors for all pairs of model states
+        in the same rootspaces as bra, ket for which a specified list of nonspectator fragments are
+        also in same state that they are in a provided input pair bra, ket.
+
+        Args:
+            rbra: integer
+                Index of a rootspace
+            rket: integer
+                Index of a rootspace
+            *inv: integers
+                Indices of nonspectator fragments.
+
+        Returns:
+            bra_rng: ndarray of integers
+                Indices of model states in the rootspace of bra in which fragments *inv are in the
+                zero state
+            ket_rng: ndarray of integers
+                Indices of model states in the rootspace of ket in which fragments *inv are in the
+                zero_state
+            o: ndarray of floats
+                Overlap * permutation factors (cf. get_ovlp_fac) corresponding to the interactions
+                bra_rng, ket_rng.
+        '''
+        inv = list (set (inv))
+        fac = self.spin_shuffle[rbra] * self.spin_shuffle[rket]
+        fac *= fermion_frag_shuffle (self.nelec_rf[rbra], inv)
+        fac *= fermion_frag_shuffle (self.nelec_rf[rket], inv)
+        spec = np.ones (self.nfrags, dtype=bool)
+        for i in inv: spec[i] = False
+        spec = np.where (spec)[0]
+        bra_rng = self._get_addr_range (rbra, *spec)
+        ket_rng = self._get_addr_range (rket, *spec)
+        specints = [self.ints[i] for i in spec]
+        o = fac * np.ones ((1,1), dtype=self.dtype)
+        for i in specints:
+            b, k = i.unique_root[rbra], i.unique_root[rket]
+            o = np.multiply.outer (i.ovlp[b][k], o).transpose (0,2,1,3)
+            o = o.reshape (o.shape[0]*o.shape[1], o.shape[2]*o.shape[3])
+        idx = np.abs(o) > 1e-8
+        if (rbra==rket): # not bra==ket because _loop_lroots_ doesn't restrict to tril
+            o[np.diag_indices_from (o)] *= 0.5
+            idx[np.triu_indices_from (idx, k=1)] = False
+        o = o[idx]
+        idx, idy = np.where (idx)
+        bra_rng, ket_rng = bra_rng[idx], ket_rng[idy]
+        return bra_rng, ket_rng, o
+
+    def _get_D1_(self, bra, ket):
+        self.d1[:] = 0.0
+        return self.d1
 
     def _get_D2_(self, bra, ket):
-        return self.tdm2s[bra,ket]
+        self.d2[:] = 0.0
+        return self.d2
 
-    def _put_D2_(self, bra, ket, D2):
-        pass
+    def _put_D1_(self, bra, ket, D1, *inv):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        bra1, ket1, wgt = self._get_spec_addr_ovlp (bra, ket, *inv)
+        self._put_SD1_(bra1, ket1, D1, wgt)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_p, self.dw_p = self.dt_p + dt, self.dw_p + dw
+
+    def _put_SD1_(self, bra, ket, D1, wgt):
+        self.tdm1s[bra,ket,:] += np.multiply.outer (wgt, D1)
+
+    def _put_D2_(self, bra, ket, D2, *inv):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        bra1, ket1, wgt = self._get_spec_addr_ovlp (bra, ket, *inv)
+        self._put_SD2_(bra1, ket1, D2, wgt)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_p, self.dw_p = self.dt_p + dt, self.dw_p + dw
+
+    def _put_SD2_(self, bra, ket, D2, wgt):
+        self.tdm2s[bra,ket,:] += np.multiply.outer (wgt, D2)
 
     # Cruncher functions
-    def _crunch_null_(self, bra, ket):
-        '''Compute the reduced density matrix elements between states bra and ket which have the
-        the same spin-up and spin-down electron numbers on all fragments (For instance, bra=ket)
-        '''
+    def _crunch_1d_(self, bra, ket, i):
+        '''Compute a single-fragment density fluctuation, for both the 1- and 2-RDMs.'''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
         d1 = self._get_D1_(bra, ket)
         d2 = self._get_D2_(bra, ket)
-        nlas = self.nlas
-        for i, inti in enumerate (self.ints):
-            p = sum (nlas[:i])
-            q = p + nlas[i]
-            d1_s_ii = inti.get_dm1 (bra, ket)
-            fac = self.get_ovlp_fac (bra, ket, i)
-            d1[:,p:q,p:q] = fac * np.asarray (d1_s_ii)
-            d2[:,p:q,p:q,p:q,p:q] = fac * np.asarray (inti.get_dm2 (bra, ket))
-            for j, intj in enumerate (self.ints[:i]):
-                assert (i>j)
-                r = sum (nlas[:j])
-                s = r + nlas[j]
-                d1_s_jj = intj.get_dm1 (bra, ket)
-                d2_s_iijj = np.multiply.outer (d1_s_ii, d1_s_jj).transpose (0,3,1,2,4,5)
-                d2_s_iijj = d2_s_iijj.reshape (4, q-p, q-p, s-r, s-r)
-                d2_s_iijj *= self.get_ovlp_fac (bra, ket, i, j)
-                d2[:,p:q,p:q,r:s,r:s] = d2_s_iijj
-                d2[(0,3),r:s,r:s,p:q,p:q] = d2_s_iijj[(0,3),...].transpose (0,3,4,1,2)
-                d2[(1,2),r:s,r:s,p:q,p:q] = d2_s_iijj[(2,1),...].transpose (0,3,4,1,2)
-                d2[(0,3),p:q,r:s,r:s,p:q] = -d2_s_iijj[(0,3),...].transpose (0,1,4,3,2)
-                d2[(0,3),r:s,p:q,p:q,r:s] = -d2_s_iijj[(0,3),...].transpose (0,3,2,1,4)
-        self._put_D1_(bra, ket, d1)
-        self._put_D2_(bra, ket, d2)
+        p, q = self.get_range (i)
+        inti = self.ints[i]
+        d1_s_ii = inti.get_dm1 (bra, ket)
+        d1[:,p:q,p:q] = np.asarray (d1_s_ii)
+        d2[:,p:q,p:q,p:q,p:q] = np.asarray (inti.get_dm2 (bra, ket))
+        self._put_D1_(bra, ket, d1, i)
+        self._put_D2_(bra, ket, d2, i)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_1d, self.dw_1d = self.dt_1d + dt, self.dw_1d + dw
+
+    def _crunch_2d_(self, bra, ket, i, j):
+        '''Compute a two-fragment density fluctuation.'''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        d2 = self._get_D2_(bra, ket)
+        inti, intj = self.ints[i], self.ints[j]
+        p, q = self.get_range (i)
+        r, s = self.get_range (j)
+        d1_s_ii = inti.get_dm1 (bra, ket)
+        d1_s_jj = intj.get_dm1 (bra, ket)
+        d2_s_iijj = np.multiply.outer (d1_s_ii, d1_s_jj).transpose (0,3,1,2,4,5)
+        d2_s_iijj = d2_s_iijj.reshape (4, q-p, q-p, s-r, s-r)
+        d2[:,p:q,p:q,r:s,r:s] = d2_s_iijj
+        d2[(0,3),r:s,r:s,p:q,p:q] = d2_s_iijj[(0,3),...].transpose (0,3,4,1,2)
+        d2[(1,2),r:s,r:s,p:q,p:q] = d2_s_iijj[(2,1),...].transpose (0,3,4,1,2)
+        d2[(0,3),p:q,r:s,r:s,p:q] = -d2_s_iijj[(0,3),...].transpose (0,1,4,3,2)
+        d2[(0,3),r:s,p:q,p:q,r:s] = -d2_s_iijj[(0,3),...].transpose (0,3,2,1,4)
+        self._put_D2_(bra, ket, d2, i, j)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_2d, self.dw_2d = self.dt_2d + dt, self.dw_2d + dw
 
     def _crunch_1c_(self, bra, ket, i, j, s1):
         '''Compute the reduced density matrix elements of a single electron hop; i.e.,
@@ -828,13 +1145,13 @@ class LSTDMint2 (object):
 
         and conjugate transpose
         '''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
         d1 = self._get_D1_(bra, ket)
         d2 = self._get_D2_(bra, ket)
         inti, intj = self.ints[i], self.ints[j]
         p, q = self.get_range (i)
         r, s = self.get_range (j)
         fac = 1
-        fac = self.get_ovlp_fac (bra, ket, i, j)
         nelec_f_bra = self.nelec_rf[self.rootaddr[bra]]
         nelec_f_ket = self.nelec_rf[self.rootaddr[ket]]
         fac *= fermion_des_shuffle (nelec_f_bra, (i, j), i)
@@ -860,18 +1177,43 @@ class LSTDMint2 (object):
         d2_ijjj = fac * np.multiply.outer (self.ints[i].get_p (bra,ket,s1),
                                            self.ints[j].get_phh (bra,ket,s1)).transpose (1,0,4,2,3)
         _crunch_1c_tdm2 (d2_ijjj, p, q, r, s, r, s)
-        # spectator fragment mean-field (should automatically be in Mulliken order)
-        for k in range (self.nfrags):
-            if k in (i, j): continue
-            fac = self.get_ovlp_fac (bra, ket, i, j, k)
-            fac *= fermion_des_shuffle (nelec_f_bra, (i, j, k), i)
-            fac *= fermion_des_shuffle (nelec_f_ket, (i, j, k), j)
-            t, u = self.get_range (k)
-            d1_skk = self.ints[k].get_dm1 (bra, ket)
-            d2_ijkk = fac * np.multiply.outer (d1_ij, d1_skk).transpose (2,0,1,3,4)
-            _crunch_1c_tdm2 (d2_ijkk, p, q, r, s, t, u)
-        self._put_D1_(bra, ket, d1)
-        self._put_D2_(bra, ket, d2)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_1c, self.dw_1c = self.dt_1c + dt, self.dw_1c + dw
+        self._put_D1_(bra, ket, d1, i, j)
+        self._put_D2_(bra, ket, d2, i, j)
+
+    def _crunch_1c1d_(self, bra, ket, i, j, k, s1):
+        '''Compute the reduced density matrix elements of a coupled electron-hop and
+        density fluctuation.'''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        d2 = self._get_D2_(bra, ket)
+        inti, intj, intk = self.ints[i], self.ints[j], self.ints[k]
+        p, q = self.get_range (i)
+        r, s = self.get_range (j)
+        t, u = self.get_range (k)
+        fac = 1
+        nelec_f_bra = self.nelec_rf[self.rootaddr[bra]]
+        nelec_f_ket = self.nelec_rf[self.rootaddr[ket]]
+        fac *= fermion_des_shuffle (nelec_f_bra, (i, j, k), i)
+        fac *= fermion_des_shuffle (nelec_f_ket, (i, j, k), j)
+        s12l = s1 * 2   # aa: 0 OR ba: 2
+        s12h = s12l + 1 # ab: 1 OR bb: 3 
+        s21l = s1       # aa: 0 OR ab: 1
+        s21h = s21l + 2 # ba: 2 OR bb: 3
+        s1s1 = s1 * 3   # aa: 0 OR bb: 3
+        def _crunch_1c_tdm2 (d2_ijkk, i0, i1, j0, j1, k0, k1):
+            d2[(s12l,s12h), i0:i1, j0:j1, k0:k1, k0:k1] = d2_ijkk
+            d2[(s21l,s21h), k0:k1, k0:k1, i0:i1, j0:j1] = d2_ijkk.transpose (0,3,4,1,2)
+            d2[s1s1, i0:i1, k0:k1, k0:k1, j0:j1] = -d2_ijkk[s1,...].transpose (0,3,2,1)
+            d2[s1s1, k0:k1, j0:j1, i0:i1, k0:k1] = -d2_ijkk[s1,...].transpose (2,1,0,3)
+        d1_ij = np.multiply.outer (self.ints[i].get_p (bra, ket, s1),
+                                   self.ints[j].get_h (bra, ket, s1))
+        d1_skk = self.ints[k].get_dm1 (bra, ket)
+        d2_ijkk = fac * np.multiply.outer (d1_ij, d1_skk).transpose (2,0,1,3,4)
+        _crunch_1c_tdm2 (d2_ijkk, p, q, r, s, t, u)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_1c1d, self.dw_1c1d = self.dt_1c1d + dt, self.dw_1c1d + dw
+        self._put_D2_(bra, ket, d2, i, j, k)
 
     def _crunch_1s_(self, bra, ket, i, j):
         '''Compute the reduced density matrix elements of a spin unit hop; i.e.,
@@ -885,16 +1227,19 @@ class LSTDMint2 (object):
 
         and conjugate transpose
         '''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
         d2 = self._get_D2_(bra, ket) # aa, ab, ba, bb -> 0, 1, 2, 3
         p, q = self.get_range (i)
         r, s = self.get_range (j)
         y, z = min (i, j), max (i, j)
-        fac = -1 * self.get_ovlp_fac (bra, ket, i, j)
+        fac = -1
         d2_spsm = fac * np.multiply.outer (self.ints[i].get_sp (bra, ket),
                                            self.ints[j].get_sm (bra, ket))
         d2[1,p:q,r:s,r:s,p:q] = d2_spsm.transpose (0,3,2,1)
         d2[2,r:s,p:q,p:q,r:s] = d2_spsm.transpose (2,1,0,3)
-        self._put_D2_(bra, ket, d2)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_1s, self.dw_1s = self.dt_1s + dt, self.dw_1s + dw
+        self._put_D2_(bra, ket, d2, i, j)
 
     def _crunch_1s1c_(self, bra, ket, i, j, k):
         '''Compute the reduced density matrix elements of a spin-charge unit hop; i.e.,
@@ -908,13 +1253,14 @@ class LSTDMint2 (object):
 
         and conjugate transpose
         '''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
         d2 = self._get_D2_(bra, ket) # aa, ab, ba, bb -> 0, 1, 2, 3
         p, q = self.get_range (i)
         r, s = self.get_range (j)
         t, u = self.get_range (k)
         nelec_f_bra = self.nelec_rf[self.rootaddr[bra]]
         nelec_f_ket = self.nelec_rf[self.rootaddr[ket]]
-        fac = -1 * self.get_ovlp_fac (bra, ket, i, j, k) # a'bb'a -> a'ab'b sign
+        fac = -1 # a'bb'a -> a'ab'b sign
         fac *= fermion_des_shuffle (nelec_f_bra, (i, j, k), i)
         fac *= fermion_des_shuffle (nelec_f_ket, (i, j, k), j)
         sp = np.multiply.outer (self.ints[i].get_p (bra, ket, 0), self.ints[j].get_h (bra, ket, 1))
@@ -922,7 +1268,9 @@ class LSTDMint2 (object):
         d2_ikkj = fac * np.multiply.outer (sp, sm).transpose (0,3,2,1) # a'bb'a -> a'ab'b transpose
         d2[1,p:q,t:u,t:u,r:s] = d2_ikkj
         d2[2,t:u,r:s,p:q,t:u] = d2_ikkj.transpose (2,3,0,1)
-        self._put_D2_(bra, ket, d2)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_1s1c, self.dw_1s1c = self.dt_1s1c + dt, self.dw_1s1c + dw
+        self._put_D2_(bra, ket, d2, i, j, k)
 
     def _crunch_2c_(self, bra, ket, i, j, k, l, s2lt):
         '''Compute the reduced density matrix elements of a two-electron hop; i.e.,
@@ -945,11 +1293,12 @@ class LSTDMint2 (object):
         Note that this includes i=k and/or j=l cases, but no other coincident fragment indices. Any
         other coincident fragment index (that is, any coincident index between the bra and the ket)
         turns this into one of the other interactions implemented in the above _crunch_ functions:
-        s1 = s2  AND SORT (ik) = SORT (jl)                 : _crunch_null_
-        s1 = s2  AND (i = j XOR i = l XOR j = k XOR k = l) : _crunch_1c_
+        s1 = s2  AND SORT (ik) = SORT (jl)                 : _crunch_1d_ and _crunch_2d_
+        s1 = s2  AND (i = j XOR i = l XOR j = k XOR k = l) : _crunch_1c_ and _crunch_1c1d_
         s1 != s2 AND (i = l AND j = k)                     : _crunch_1s_
         s1 != s2 AND (i = l XOR j = k)                     : _crunch_1s1c_
         '''
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
         # s2lt: 0, 1, 2 -> aa, ab, bb
         # s2: 0, 1, 2, 3 -> aa, ab, ba, bb
         s2  = (0, 1, 3)[s2lt] # aa, ab, bb
@@ -959,7 +1308,7 @@ class LSTDMint2 (object):
         nelec_f_bra = self.nelec_rf[self.rootaddr[bra]]
         nelec_f_ket = self.nelec_rf[self.rootaddr[ket]]
         d2 = self._get_D2_(bra, ket)
-        fac = self.get_ovlp_fac (bra, ket, i, j, k, l)
+        fac = 1
         if i == k:
             pp = self.ints[i].get_pp (bra, ket, s2lt)
             if s2lt != 1: assert (np.all (np.abs (pp + pp.T)) < 1e-8), '{}'.format (
@@ -990,30 +1339,49 @@ class LSTDMint2 (object):
         if s2 == s2T: # same-spin only: exchange happens
             d2[s2,p:q,v:w,t:u,r:s] = -d2_ijkl.transpose (0,3,2,1)
             d2[s2,t:u,r:s,p:q,v:w] = -d2_ijkl.transpose (2,1,0,3)
-        self._put_D2_(bra, ket, d2)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_2c, self.dw_2c = self.dt_2c + dt, self.dw_2c + dw
+        self._put_D2_(bra, ket, d2, i, j, k, l)
 
     def _loop_lroots_(self, _crunch_fn, *row):
-        bra0, bra1 = self.offs_lroots[row[0]]
-        ket0, ket1 = self.offs_lroots[row[1]]
+        if _crunch_fn.__name__ in ('_crunch_1c_', '_crunch_1c1d_', '_crunch_2c_'):
+            inv = row[2:-1]
+        else:
+            inv = row[2:]
+        self._prepare_spec_addr_ovlp_(row[0], row[1], *inv)
+        bra_rng = self._get_addr_range (row[0], *inv)
+        ket_rng = self._get_addr_range (row[1], *inv)
         lrow = [l for l in row]
-        for lrow[0], lrow[1] in product (range (bra0, bra1), range (ket0, ket1)):
+        for lrow[0], lrow[1] in product (bra_rng, ket_rng):
             _crunch_fn (*lrow)
 
     def _crunch_all_(self):
-        for row in self.exc_null: self._loop_lroots_(self._crunch_null_, *row)
+        for row in self.exc_1d: self._loop_lroots_(self._crunch_1d_, *row)
+        for row in self.exc_2d: self._loop_lroots_(self._crunch_2d_, *row)
         for row in self.exc_1c: self._loop_lroots_(self._crunch_1c_, *row)
+        for row in self.exc_1c1d: self._loop_lroots_(self._crunch_1c1d_, *row)
         for row in self.exc_1s: self._loop_lroots_(self._crunch_1s_, *row)
         for row in self.exc_1s1c: self._loop_lroots_(self._crunch_1s1c_, *row)
         for row in self.exc_2c: self._loop_lroots_(self._crunch_2c_, *row)
-        for i0, i1 in self.offs_lroots:
-            for bra, ket in combinations (range (i0, i1), 2):
-                self._crunch_null_(bra, ket)
         self._add_transpose_()
-        for state in range (self.nstates): self._crunch_null_(state, state)
 
     def _add_transpose_(self):
         self.tdm1s += self.tdm1s.conj ().transpose (1,0,2,4,3)
         self.tdm2s += self.tdm2s.conj ().transpose (1,0,2,4,3,6,5)
+
+    def _umat_linequiv_loop_(self, *args):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        for ifrag, inti in enumerate (self.ints):
+            for iroot, umat in inti.umat_root.items ():
+                self._umat_linequiv_(ifrag, iroot, umat, *args)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_u, self.dw_u = self.dt_u + dt, self.dw_u + dw
+
+    def _umat_linequiv_(self, ifrag, iroot, umat, *args):
+        self.tdm1s = umat_dot_1frag_(self.tdm1s, umat, self.lroots, ifrag, iroot, axis=0) 
+        self.tdm1s = umat_dot_1frag_(self.tdm1s, umat, self.lroots, ifrag, iroot, axis=1) 
+        self.tdm2s = umat_dot_1frag_(self.tdm2s, umat, self.lroots, ifrag, iroot, axis=0) 
+        self.tdm2s = umat_dot_1frag_(self.tdm2s, umat, self.lroots, ifrag, iroot, axis=1) 
 
     def kernel (self):
         ''' Main driver method of class.
@@ -1027,10 +1395,26 @@ class LSTDMint2 (object):
                 timestamp of entry into this function, for profiling by caller
         '''
         t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
+        self.init_profiling ()
         self.tdm1s = np.zeros ([self.nstates,]*2 + [2,] + [self.norb,]*2, dtype=self.dtype)
         self.tdm2s = np.zeros ([self.nstates,]*2 + [4,] + [self.norb,]*4, dtype=self.dtype)
         self._crunch_all_()
+        self._umat_linequiv_loop_()
         return self.tdm1s, self.tdm2s, t0
+
+    def sprint_profile (self):
+        fmt_str = '{:>5s} CPU: {:9.2f} ; wall: {:9.2f}'
+        profile = fmt_str.format ('1d', self.dt_1d, self.dw_1d)
+        profile += '\n' + fmt_str.format ('2d', self.dt_2d, self.dw_2d)
+        profile += '\n' + fmt_str.format ('1c', self.dt_1c, self.dw_1c)
+        profile += '\n' + fmt_str.format ('1c1d', self.dt_1c1d, self.dw_1c1d)
+        profile += '\n' + fmt_str.format ('1s', self.dt_1s, self.dw_1s)
+        profile += '\n' + fmt_str.format ('1s1c', self.dt_1s1c, self.dw_1s1c)
+        profile += '\n' + fmt_str.format ('2c', self.dt_2c, self.dw_2c)
+        profile += '\n' + fmt_str.format ('ovlp', self.dt_o, self.dw_o)
+        profile += '\n' + fmt_str.format ('umat', self.dt_u, self.dw_u)
+        profile += '\n' + fmt_str.format ('put', self.dt_p, self.dw_p)
+        return profile
 
 class HamS2ovlpint (LSTDMint2):
     __doc__ = LSTDMint2.__doc__ + '''
@@ -1050,34 +1434,53 @@ class HamS2ovlpint (LSTDMint2):
     # Hamiltonian in addition to h1 and h2, which are spin-symmetric
 
     def __init__(self, ints, nlas, hopping_index, lroots, h1, h2, mask_bra_space=None,
-                 mask_ket_space=None, dtype=np.float64):
+                 mask_ket_space=None, log=None, dtype=np.float64):
         LSTDMint2.__init__(self, ints, nlas, hopping_index, lroots, mask_bra_space=mask_bra_space,
-                           mask_ket_space=mask_ket_space, dtype=dtype)
+                           mask_ket_space=mask_ket_space, log=log, dtype=dtype)
         if h1.ndim==2: h1 = np.stack ([h1,h1], axis=0)
         self.h1 = h1
         self.h2 = h2
 
-    def _get_D1_(self, bra, ket):
-        self.d1[:] = 0.0
-        return self.d1
-
-    def _get_D2_(self, bra, ket):
-        self.d2[:] = 0.0
-        return self.d2
-
-    def _put_D1_(self, bra, ket, D1):
-        self.ham[bra,ket] += np.dot (self.h1.ravel (), D1.ravel ())
+    def _put_D1_(self, bra, ket, D1, *inv):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        ham = np.dot (self.h1.ravel (), D1.ravel ())
         M1 = D1[0] - D1[1]
         D1 = D1.sum (0)
-        self.s2[bra,ket] += (np.trace (M1)/2)**2 + np.trace (D1)/2
+        #self.s2[bra,ket] += (np.trace (M1)/2)**2 + np.trace (D1)/2
+        s2 = 3*np.trace (D1)/4
+        bra1, ket1, wgt = self._get_spec_addr_ovlp (bra, ket, *inv)
+        self._put_ham_s2_(bra1, ket1, ham, s2, wgt)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_p, self.dw_p = self.dt_p + dt, self.dw_p + dw
 
-    def _put_D2_(self, bra, ket, D2):
-        self.ham[bra,ket] += np.dot (self.h2.ravel (), D2.sum (0).ravel ()) / 2
-        self.s2[bra,ket] -= np.einsum ('pqqp->', D2[1] + D2[2]) / 2
+    def _put_ham_s2_(self, bra, ket, ham, s2, wgt):
+        self.ham[bra,ket] += wgt * ham
+        self.s2[bra,ket] += wgt * s2
+
+    def _put_D2_(self, bra, ket, D2, *inv):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        ham = np.dot (self.h2.ravel (), D2.sum (0).ravel ()) / 2
+        M2 = np.einsum ('sppqq->s', D2) / 4
+        s2 = M2[0] + M2[3] - M2[1] - M2[2]
+        s2 -= np.einsum ('pqqp->', D2[1] + D2[2]) / 2
+        bra1, ket1, wgt = self._get_spec_addr_ovlp (bra, ket, *inv)
+        self._put_ham_s2_(bra1, ket1, ham, s2, wgt)
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_p, self.dw_p = self.dt_p + dt, self.dw_p + dw
 
     def _add_transpose_(self):
         self.ham += self.ham.T
         self.s2 += self.s2.T
+
+    def _umat_linequiv_(self, ifrag, iroot, umat, *args):
+        ovlp = args[0]
+        self.ham = umat_dot_1frag_(self.ham, umat, self.lroots, ifrag, iroot, axis=0) 
+        self.ham = umat_dot_1frag_(self.ham, umat, self.lroots, ifrag, iroot, axis=1) 
+        self.s2 = umat_dot_1frag_(self.s2, umat, self.lroots, ifrag, iroot, axis=0) 
+        self.s2 = umat_dot_1frag_(self.s2, umat, self.lroots, ifrag, iroot, axis=1) 
+        ovlp = umat_dot_1frag_(ovlp, umat, self.lroots, ifrag, iroot, axis=0) 
+        ovlp = umat_dot_1frag_(ovlp, umat, self.lroots, ifrag, iroot, axis=1) 
+        return ovlp
 
     def kernel (self):
         ''' Main driver method of class.
@@ -1093,16 +1496,19 @@ class HamS2ovlpint (LSTDMint2):
                 timestamp of entry into this function, for profiling by caller
         '''
         t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
-        self.d1 = np.zeros ([2,]+[self.norb,]*2, dtype=self.dtype)
-        self.d2 = np.zeros ([4,]+[self.norb,]*4, dtype=self.dtype)
+        self.init_profiling ()
         self.ham = np.zeros ([self.nstates,]*2, dtype=self.dtype)
         self.s2 = np.zeros ([self.nstates,]*2, dtype=self.dtype)
         self._crunch_all_()
+        t1, w1 = lib.logger.process_clock (), lib.logger.perf_counter ()
         ovlp = np.zeros ([self.nstates,]*2, dtype=self.dtype)
         def crunch_ovlp (bra_sp, ket_sp):
-            o = self.ints[-1].ovlp[bra_sp][ket_sp]
+            i = self.ints[-1]
+            b, k = i.unique_root[bra_sp], i.unique_root[ket_sp]
+            o = i.ovlp[b][k] / (1 + int (bra_sp==ket_sp))
             for i in self.ints[-2::-1]:
-                o = np.multiply.outer (o, i.ovlp[bra_sp][ket_sp]).transpose (0,2,1,3)
+                b, k = i.unique_root[bra_sp], i.unique_root[ket_sp]
+                o = np.multiply.outer (o, i.ovlp[b][k]).transpose (0,2,1,3)
                 o = o.reshape (o.shape[0]*o.shape[1], o.shape[2]*o.shape[3])
             o *= self.spin_shuffle[bra_sp]
             o *= self.spin_shuffle[ket_sp]
@@ -1111,7 +1517,9 @@ class HamS2ovlpint (LSTDMint2):
             ovlp[i0:i1,j0:j1] = o
         for bra_sp, ket_sp in self.exc_null: crunch_ovlp (bra_sp, ket_sp)
         ovlp += ovlp.T
-        for iroot in range (self.nroots): crunch_ovlp (iroot, iroot)
+        dt, dw = logger.process_clock () - t1, logger.perf_counter () - w1
+        self.dt_o, self.dw_o = self.dt_o + dt, self.dw_o + dw
+        self._umat_linequiv_loop_(ovlp)
         return self.ham, self.s2, ovlp, t0
 
 class LRRDMint (LSTDMint2):
@@ -1131,30 +1539,30 @@ class LRRDMint (LSTDMint2):
     # spinorbital basis
 
     def __init__(self, ints, nlas, hopping_index, lroots, si, mask_bra_space=None,
-                 mask_ket_space=None, dtype=np.float64):
+                 mask_ket_space=None, log=None, dtype=np.float64):
         LSTDMint2.__init__(self, ints, nlas, hopping_index, lroots, mask_bra_space=mask_bra_space,
-                           mask_ket_space=mask_ket_space, dtype=dtype)
+                           mask_ket_space=mask_ket_space, log=log, dtype=dtype)
         self.nroots_si = si.shape[-1]
+        si = si.copy ()
+        self._umat_linequiv_loop_(si)
         self.si_dm = np.stack ([np.dot (si[:,i:i+1],si[:,i:i+1].conj ().T)
             for i in range (self.nroots_si)], axis=-1)
 
-    def _get_D1_(self, bra, ket):
-        self.d1[:] = 0.0
-        return self.d1
+    def _put_SD1_(self, bra, ket, D1, wgt):
+        fac = np.dot (wgt, self.si_dm[bra,ket])
+        self.rdm1s[:] += np.multiply.outer (fac, D1)
 
-    def _get_D2_(self, bra, ket):
-        self.d2[:] = 0.0
-        return self.d2
-
-    def _put_D1_(self, bra, ket, D1):
-        self.rdm1s[:] += np.multiply.outer (self.si_dm[bra,ket,:], D1)
-
-    def _put_D2_(self, bra, ket, D2):
-        self.rdm2s[:] += np.multiply.outer (self.si_dm[bra,ket,:], D2)
+    def _put_SD2_(self, bra, ket, D2, wgt):
+        wgt = np.dot (wgt, self.si_dm[bra,ket])
+        self.rdm2s[:] += np.multiply.outer (wgt, D2)
 
     def _add_transpose_(self):
         self.rdm1s += self.rdm1s.conj ().transpose (0,1,3,2)
         self.rdm2s += self.rdm2s.conj ().transpose (0,1,3,2,5,4)
+
+    def _umat_linequiv_(self, ifrag, iroot, umat, *args):
+        si = args[0]
+        return umat_dot_1frag_(si, umat.conj ().T, self.lroots, ifrag, iroot, axis=0) 
 
     def kernel (self):
         ''' Main driver method of class.
@@ -1168,8 +1576,7 @@ class LRRDMint (LSTDMint2):
                 timestamp of entry into this function, for profiling by caller
         '''
         t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
-        self.d1 = np.zeros ([2,]+[self.norb,]*2, dtype=self.dtype)
-        self.d2 = np.zeros ([4,]+[self.norb,]*4, dtype=self.dtype)
+        self.init_profiling ()
         self.rdm1s = np.zeros ([self.nroots_si,] + list (self.d1.shape), dtype=self.dtype)
         self.rdm2s = np.zeros ([self.nroots_si,] + list (self.d2.shape), dtype=self.dtype)
         self._crunch_all_()
@@ -1188,14 +1595,15 @@ class ContractHamCI (LSTDMint2):
         h2 : ndarray of size ncas**4
             Contains 2-electron Hamiltonian amplitudes in second quantization
     '''
-    def __init__(self, ints, nlas, hopping_index, lroots, h1, h2, nbra=1, dtype=np.float64):
+    def __init__(self, ints, nlas, hopping_index, lroots, h1, h2, nbra=1,
+                 log=None, dtype=np.float64):
         nfrags, _, nroots, _ = hopping_index.shape
         if nfrags > 2: raise NotImplementedError ("Spectator fragments in _crunch_1c_")
         nket = nroots - nbra
         HamS2ovlpint.__init__(self, ints, nlas, hopping_index, lroots, h1, h2,
                               mask_bra_space = list (range (nket, nroots)),
                               mask_ket_space = list (range (nket)),
-                              dtype=dtype)
+                              log=log, dtype=dtype)
         self.nbra = nbra
         self.hci_fr_pabq = self._init_vecs ()
 
@@ -1218,9 +1626,6 @@ class ContractHamCI (LSTDMint2):
             hci_fr_pabq.append (hci_r_pabq)
         return hci_fr_pabq
 
-    def _crunch_null_(self, bra, ket):
-        raise NotImplementedError
-
     def _crunch_1c_(self, bra, ket, i, j, s1):
         '''Perform a single electron hop; i.e.,
         
@@ -1237,7 +1642,6 @@ class ContractHamCI (LSTDMint2):
         p, q = self.get_range (i)
         r, s = self.get_range (j)
         fac = 1
-        fac = self.get_ovlp_fac (bra, ket, i, j)
         nelec_f_bra = self.nelec_rf[self.rootaddr[bra]]
         nelec_f_ket = self.nelec_rf[self.rootaddr[ket]]
         fac *= fermion_des_shuffle (nelec_f_bra, (i, j), i)
@@ -1259,7 +1663,7 @@ class ContractHamCI (LSTDMint2):
                 axes=((0,1,2),(2,0,1)))
             h_12 = np.tensordot (D_i, h2_ijjj, axes=1).transpose (1,2,0)
             hci_f_ab[j] += fac * self.ints[j].contract_h01 (s1, h_01, h_12, ket)
-        self._put_vecs_(bra, ket, hci_f_ab)
+        self._put_vecs_(bra, ket, hci_f_ab, i, j)
         return
 
     def _crunch_1s_(self, bra, ket, i, j):
@@ -1280,28 +1684,48 @@ class ContractHamCI (LSTDMint2):
         assert (err==0)
         return bra + rem
 
-    def _get_vecs_(self, bra, ket):
+    def _bra_address (self, bra):
         bra_r = self.rootaddr[bra]
-        bra_env = np.array ([inti.fragaddr[bra] for inti in self.ints])
+        bra_env = self.envaddr[bra]
         lroots_bra_r = self.lroots[:,bra_r]
         bra_r = bra_r + self.nbra - self.nroots
-        hci_f_ab = []
         excfrags = set (np.where (bra_env==0)[0])
-        hci_f_ab = [None for i in range (self.nfrags)]
+        bra_envaddr = []
         for i in excfrags:
-            hci_r_pabq = self.hci_fr_pabq[i]
             lroots_i = lroots_bra_r.copy ()
             lroots_i[i] = 1
             strides = np.append ([1], np.cumprod (lroots_i[:-1]))
-            bra_envaddr = np.dot (strides, bra_env)
-            hci_f_ab[i] = hci_r_pabq[bra_r][bra_envaddr,:,:,ket]
-        return hci_f_ab, set (excfrags)
+            bra_envaddr.append (np.dot (strides, bra_env))
+        return bra_r, bra_envaddr, excfrags
 
-    def _put_vecs_(self, bra, ket, vecs):
-        pass
+    def _get_vecs_(self, bra, ket):
+        bra_r, bra_envaddr, excfrags = self._bra_address (bra)
+        hci_f_ab = [0 for i in range (self.nfrags)]
+        for i, addr in zip (excfrags, bra_envaddr):
+            hci_r_pabq = self.hci_fr_pabq[i]
+            # TODO: buffer
+            hci_f_ab[i] = np.zeros_like (hci_r_pabq[bra_r][addr,:,:,ket])
+        return hci_f_ab, excfrags
+
+    def _put_vecs_(self, bra, ket, vecs, *inv):
+        t0, w0 = logger.process_clock (), logger.perf_counter ()
+        bras, kets, facs = self._get_spec_addr_ovlp (bra, ket, *inv)
+        for bra, ket, fac in zip (bras, kets, facs):
+            self._put_Svecs_(bra, ket, [fac*vec for vec in vecs])
+        dt, dw = logger.process_clock () - t0, logger.perf_counter () - w0
+        self.dt_p, self.dw_p = self.dt_p + dt, self.dw_p + dw
+
+    def _put_Svecs_(self, bra, ket, vecs):
+        bra_r, bra_envaddr, excfrags = self._bra_address (bra)
+        for i, addr in zip (excfrags, bra_envaddr):
+            self.hci_fr_pabq[i][bra_r][addr,:,:,ket] += vecs[i]
 
     def _crunch_all_(self):
         for row in self.exc_1c: self._loop_lroots_(self._crunch_1c_, *row)
+
+    def _umat_linequiv_(self, ifrag, iroot, umat, *args):
+        # TODO: is this even possible?
+        pass
 
     def kernel (self):
         ''' Main driver method of class.
@@ -1310,14 +1734,16 @@ class ContractHamCI (LSTDMint2):
             hci_fr_pabq : list of length nfrags of list of length nroots of ndarray
         '''
         t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
+        self.init_profiling ()
         for hci_r_pabq in self.hci_fr_pabq:
             for hci_pabq in hci_r_pabq:
                 hci_pabq[:,:,:,:] = 0.0
         self._crunch_all_()
+        self._umat_linequiv_loop_()
         return self.hci_fr_pabq, t0
 
 
-def make_ints (las, ci, nelec_frs):
+def make_ints (las, ci, nelec_frs, screen_linequiv=True):
     ''' Build fragment-local intermediates (`LSTDMint1`) for LASSI o1
 
     Args:
@@ -1327,6 +1753,11 @@ def make_ints (las, ci, nelec_frs):
         nelec_frs : ndarray of shape (nfrags,nroots,2)
             Number of electrons of each spin in each rootspace in each
             fragment
+
+    Kwargs:
+        screen_linequiv : logical
+            Whether to compress data by aggressively identifying linearly equivalent
+            rootspaces and storing the relevant unitary matrices.
 
     Returns:
         hopping_index : ndarray of ints of shape (nfrags, 2, nroots, nroots)
@@ -1344,9 +1775,12 @@ def make_ints (las, ci, nelec_frs):
     ints = []
     for ifrag in range (nfrags):
         tdmint = LSTDMint1 (ci[ifrag], hopping_index[ifrag], zerop_index, onep_index, nlas[ifrag],
-                            nroots, nelec_frs[ifrag], rootaddr, fragaddr[ifrag], ifrag)
+                            nroots, nelec_frs[ifrag], rootaddr, fragaddr[ifrag], ifrag,
+                            screen_linequiv=screen_linequiv)
         lib.logger.timer (las, 'LAS-state TDM12s fragment {} intermediate crunching'.format (
             ifrag), *tdmint.time_crunch)
+        lib.logger.debug (las, 'UNIQUE ROOTSPACES OF FRAG %d: %d/%d', ifrag,
+                          np.count_nonzero (tdmint.root_unique), nroots)
         ints.append (tdmint)
     return hopping_index, ints, lroots
 
@@ -1367,6 +1801,7 @@ def make_stdm12s (las, ci, nelec_frs, **kwargs):
         tdm2s : ndarray of shape (nroots,2,ncas,ncas,2,ncas,ncas,nroots)
             Contains 2-body LAS state transition density matrices
     '''
+    log = lib.logger.new_logger (las, las.verbose)
     nlas = las.ncas_sub
     ncas = las.ncas
     nroots = nelec_frs.shape[1]
@@ -1376,10 +1811,12 @@ def make_stdm12s (las, ci, nelec_frs, **kwargs):
 
     # Second pass: upper-triangle
     t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
-    outerprod = LSTDMint2 (ints, nlas, hopping_index, lroots, dtype=ci[0][0].dtype)
+    outerprod = LSTDMint2 (ints, nlas, hopping_index, lroots, dtype=ci[0][0].dtype, log=log)
     lib.logger.timer (las, 'LAS-state TDM12s second intermediate indexing setup', *t0)        
     tdm1s, tdm2s, t0 = outerprod.kernel ()
     lib.logger.timer (las, 'LAS-state TDM12s second intermediate crunching', *t0)        
+    if las.verbose >= lib.logger.TIMER_LEVEL:
+        lib.logger.info (las, 'LAS-state TDM12s crunching profile:\n%s', outerprod.sprint_profile ())
 
     # Put tdm1s in PySCF convention: [p,q] -> q'p
     nstates = np.sum (np.prod (lroots, axis=0))
@@ -1410,6 +1847,7 @@ def ham (las, h1, h2, ci, nelec_frs, **kwargs):
         ovlp : ndarray of shape (nroots,nroots)
             Overlap matrix of LAS product states
     '''
+    log = lib.logger.new_logger (las, las.verbose)
     nlas = las.ncas_sub
 
     # First pass: single-fragment intermediates
@@ -1417,10 +1855,12 @@ def ham (las, h1, h2, ci, nelec_frs, **kwargs):
 
     # Second pass: upper-triangle
     t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
-    outerprod = HamS2ovlpint (ints, nlas, hopping_index, lroots, h1, h2, dtype=ci[0][0].dtype)
+    outerprod = HamS2ovlpint (ints, nlas, hopping_index, lroots, h1, h2, dtype=ci[0][0].dtype, log=log)
     lib.logger.timer (las, 'LASSI Hamiltonian second intermediate indexing setup', *t0)        
     ham, s2, ovlp, t0 = outerprod.kernel ()
     lib.logger.timer (las, 'LASSI Hamiltonian second intermediate crunching', *t0)        
+    if las.verbose >= lib.logger.TIMER_LEVEL:
+        lib.logger.info (las, 'LASSI Hamiltonian crunching profile:\n%s', outerprod.sprint_profile ())
     return ham, s2, ovlp
 
 
@@ -1443,6 +1883,7 @@ def roots_make_rdm12s (las, ci, nelec_frs, si, **kwargs):
         rdm2s : ndarray of shape (nroots_si,2,ncas,ncas,2,ncas,ncas)
             Spin-separated 2-body reduced density matrices of LASSI states
     '''
+    log = lib.logger.new_logger (las, las.verbose)
     nlas = las.ncas_sub
     ncas = las.ncas
     nroots_si = si.shape[-1]
@@ -1452,10 +1893,12 @@ def roots_make_rdm12s (las, ci, nelec_frs, si, **kwargs):
 
     # Second pass: upper-triangle
     t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
-    outerprod = LRRDMint (ints, nlas, hopping_index, lroots, si, dtype=ci[0][0].dtype)
+    outerprod = LRRDMint (ints, nlas, hopping_index, lroots, si, dtype=ci[0][0].dtype, log=log)
     lib.logger.timer (las, 'LASSI root RDM12s second intermediate indexing setup', *t0)        
     rdm1s, rdm2s, t0 = outerprod.kernel ()
     lib.logger.timer (las, 'LASSI root RDM12s second intermediate crunching', *t0)
+    if las.verbose >= lib.logger.TIMER_LEVEL:
+        lib.logger.info (las, 'LASSI root RDM12s crunching profile:\n%s', outerprod.sprint_profile ())
 
     # Put rdm1s in PySCF convention: [p,q] -> q'p
     rdm1s = rdm1s.transpose (0,1,3,2)
@@ -1499,6 +1942,8 @@ def contract_ham_ci (las, h1, h2, ci_fr_ket, nelec_frs_ket, ci_fr_bra, nelec_frs
             Element i,j is an ndarray of shape (ndim_bra//ci_fr_bra[i][j].shape[0],
             ndeta_bra[i,j],ndetb_bra[i,j],ndim_ket).
     '''
+    log = lib.logger.new_logger (las, las.verbose)
+    log = lib.logger.new_logger (las, las.verbose)
     nlas = las.ncas_sub
     nfrags, nbra = nelec_frs_bra.shape[:2]
     nket = nelec_frs_ket.shape[1]
@@ -1506,14 +1951,14 @@ def contract_ham_ci (las, h1, h2, ci_fr_ket, nelec_frs_ket, ci_fr_bra, nelec_frs
     nelec_frs = np.append (nelec_frs_ket, nelec_frs_bra, axis=1)
 
     # First pass: single-fragment intermediates
-    hopping_index, ints, lroots = make_ints (las, ci, nelec_frs)
+    hopping_index, ints, lroots = make_ints (las, ci, nelec_frs, screen_linequiv=False)
 
     # Second pass: upper-triangle
     t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
     contracter = ContractHamCI (ints, nlas, hopping_index, lroots, h1, h2, nbra=nbra,
-                                dtype=ci[0][0].dtype)
-    lib.logger.timer (las, 'LASSI root RDM12s second intermediate indexing setup', *t0)        
+                                dtype=ci[0][0].dtype, log=log)
+    lib.logger.timer (las, 'LASSI Hamiltonian contraction second intermediate indexing setup', *t0)        
     hket_fr_pabq, t0 = contracter.kernel ()
-    lib.logger.timer (las, 'LASSI root RDM12s second intermediate crunching', *t0)
+    lib.logger.timer (las, 'LASSI Hamiltonian contraction second intermediate crunching', *t0)
 
     return hket_fr_pabq

--- a/my_pyscf/lassi/sitools.py
+++ b/my_pyscf/lassi/sitools.py
@@ -2,8 +2,9 @@ import numpy as np
 from pyscf import lib, symm
 from scipy import linalg
 from mrh.my_pyscf.mcscf.lasci import get_space_info
-from mrh.my_pyscf.lassi.lassi import ham_2q, root_make_rdm12s, LASSI
 from mrh.my_pyscf.lassi.citools import get_lroots, get_rootaddr_fragaddr
+from mrh.my_pyscf.lassi.lassi import root_make_rdm12s, LASSI, ham_2q
+from mrh.my_pyscf.lassi.op_o1 import fermion_spin_shuffle
 
 def decompose_sivec_by_rootspace (las, si, ci=None):
     '''Decompose a set of LASSI vectors as
@@ -481,7 +482,6 @@ def sivec_fermion_spin_shuffle (si0, nelec_frs, lroots):
         si1: ndarray of shape (ndim,*)
             si0 with permuted row signs
     '''
-    from mrh.my_pyscf.lassi.op_o1 import fermion_spin_shuffle
     nelec_rsf = np.asarray (nelec_frs).transpose (1,2,0)
     rootaddr = get_rootaddr_fragaddr (lroots)[0]
     si1 = si0.copy ()
@@ -538,6 +538,8 @@ def sivec_vacuum_shuffle (si0, nelec_frs, lroots, nelec_vac=None, state=None):
         idx = (rootaddr==iroot)
         si1[idx,:] *= (1,-1)[nperms%2]
     return si1
+
+
 
 
 

--- a/my_pyscf/lassi/spaces.py
+++ b/my_pyscf/lassi/spaces.py
@@ -4,13 +4,15 @@ from pyscf.fci.direct_spin1 import _unpack_nelec
 from pyscf.fci import cistring
 from pyscf.lib import logger
 from pyscf.lo.orth import vec_lowdin
-from pyscf import symm
+from pyscf import symm, __config__
 from mrh.my_pyscf.fci import csf_solver
 from mrh.my_pyscf.fci.spin_op import contract_sdown, contract_sup
 from mrh.my_pyscf.fci.csfstring import CSFTransformer
 from mrh.my_pyscf.fci.csfstring import ImpossibleSpinError
 from mrh.my_pyscf.mcscf.productstate import ImpureProductStateFCISolver
 import itertools
+
+LINDEP_THRESH = getattr (__config__, 'lassi_lindep_thresh', 1.0e-5)
 
 class SingleLASRootspace (object):
     def __init__(self, las, spins, smults, charges, weight, nlas=None, nelelas=None, stdout=None,
@@ -41,6 +43,8 @@ class SingleLASRootspace (object):
         self.nholeu = self.nlas - self.nelecu
         self.nholed = self.nlas - self.nelecd
 
+        self.entmap = tuple ()
+
     def __eq__(self, other):
         if self.nfrag != other.nfrag: return False
         return (np.all (self.spins==other.spins) and 
@@ -49,7 +53,7 @@ class SingleLASRootspace (object):
 
     def __hash__(self):
         return hash (tuple ([self.nfrag,] + list (self.spins) + list (self.smults)
-                            + list (self.charges)))
+                            + list (self.charges) + list (self.entmap)))
 
     def possible_excitation (self, i, a, s):
         i, a, s = np.atleast_1d (i, a, s)
@@ -157,16 +161,22 @@ class SingleLASRootspace (object):
             idx_valid = np.all (spins_table>-self.smults[None,:], axis=1)
             spins_table = spins_table[idx_valid,:]
         for spins in spins_table:
-            yield SingleLASRootspace (self.las, spins, self.smults, self.charges, 0, nlas=self.nlas,
-                                  nelelas=self.nelelas, stdout=self.stdout, verbose=self.verbose)
+            sp = SingleLASRootspace (self.las, spins, self.smults, self.charges, 0, nlas=self.nlas,
+                                     nelelas=self.nelelas, stdout=self.stdout, verbose=self.verbose)
+            sp.entmap = self.entmap
+            yield sp
 
     def has_ci (self):
         if self.ci is None: return False
         return all ([c is not None for c in self.ci])
 
-    def get_ci_szrot (self):
+    def get_ci_szrot (self, ifrags=None):
         '''Generate the sets of CI vectors in which each vector for each fragment
         has the sz axis rotated in all possible ways.
+
+        Kwargs:
+            ifrags: list of integers
+                Optionally restrict ci_sz to particular fragments identified by ifrags
 
         Returns:
             ci_sz: list of dict of type {integer: ndarray}
@@ -175,7 +185,8 @@ class SingleLASRootspace (object):
         '''
         ci_sz = []
         ndet = self.get_ndet ()
-        for ifrag in range (self.nfrag):
+        if ifrags is None: ifrags = range (self.nfrag)
+        for ifrag in ifrags:
             norb, sz, ci = self.nlas[ifrag], self.spins[ifrag], self.ci[ifrag]
             ndeta, ndetb = ndet[ifrag]
             nelec = self.neleca[ifrag], self.nelecb[ifrag]
@@ -229,24 +240,28 @@ class SingleLASRootspace (object):
         e_spin = 'a' if np.any (self.neleca!=other.neleca) else 'b'
         src_ds = 'u' if self.smults[src_frag]>other.smults[src_frag] else 'd'
         dest_ds = 'u' if self.smults[dest_frag]>other.smults[dest_frag] else 'd'
-        return src_frag, dest_frag, e_spin, src_ds, dest_ds
+        lroots_s = min (other.nelecu[src_frag], other.nholed[dest_frag])
+        return src_frag, dest_frag, e_spin, src_ds, dest_ds, lroots_s
+
+    def set_entmap_(self, ref):
+        idx = np.where (self.excited_fragments (ref))[0]
+        idx = tuple (set (idx))
+        self.entmap = tuple ((idx,))
+        #self.entmap[:,:] = 0
+        #for i, j in itertools.combinations (idx, 2):
+        #    self.entmap[i,j] = self.entmap[j,i] = 1
 
     def single_excitation_description_string (self, other):
-        src, dest, e_spin, src_ds, dest_ds = self.describe_single_excitation (other)
-        fmt_str = '{:d}({:s}) --{:s}--> {:d}({:s})'
-        return fmt_str.format (src, src_ds, e_spin, dest, dest_ds)
+        src, dest, e_spin, src_ds, dest_ds, lroots_s = self.describe_single_excitation (other)
+        fmt_str = '{:d}({:s}) --{:s}--> {:d}({:s}) ({:d} lroots)'
+        return fmt_str.format (src, src_ds, e_spin, dest, dest_ds, lroots_s)
 
     def compute_single_excitation_lroots (self, ref):
         if isinstance (ref, (list, tuple)):
             lroots = np.array ([self.compute_single_excitation_lroots (r) for r in ref])
             return np.amax (lroots)
         assert (self.is_single_excitation_of (ref))
-        src, dest, e_spin = self.describe_single_excitation (ref)[:3]
-        if e_spin == 'a':
-            nelec, nhole = ref.neleca, ref.nholea
-        else:
-            nelec, nhole = ref.nelecb, ref.nholeb
-        return min (nelec[src], nhole[dest])
+        return self.describe_single_excitation (ref)[5]
 
     def is_spin_shuffle_of (self, other):
         if np.any (self.nelec != other.nelec): return False
@@ -259,6 +274,7 @@ class SingleLASRootspace (object):
         return [ci_sz[ifrag][self.spins[ifrag]] for ifrag in range (self.nfrag)]
 
     def excited_fragments (self, other):
+        if other is None: return np.ones (self.nfrag, dtype=bool)
         dneleca = self.neleca - other.neleca
         dnelecb = self.nelecb - other.nelecb
         dsmults = self.smults - other.smults
@@ -302,9 +318,12 @@ class SingleLASRootspace (object):
         if ci is not None:
             ci1 = [c for c in self.ci]
             ci1[ifrag] = ci
-        return SingleLASRootspace (self.las, spins1, smults1, self.charges, 0, nlas=self.nlas,
-                                   nelelas=self.nelelas, stdout=self.stdout, verbose=self.verbose,
-                                   ci=ci1)
+        sp = SingleLASRootspace (self.las, spins1, smults1, self.charges, 0, nlas=self.nlas,
+                                 nelelas=self.nelelas, stdout=self.stdout, verbose=self.verbose,
+                                 ci=ci1)
+        sp.entmap = self.entmap
+        assert (ci is sp.ci[ifrag])
+        return sp
 
     def is_orthogonal_by_smult (self, other):
         if isinstance (other, (list, tuple)):
@@ -342,6 +361,58 @@ class SingleLASRootspace (object):
         return ImpureProductStateFCISolver (fcisolvers, stdout=self.stdout, lweights=lweights, 
                                             verbose=self.verbose)
 
+    def merge_(self, other, ref=None, lindep_thresh=LINDEP_THRESH):
+        idx = self.excited_fragments (ref)
+        ndet = self.get_ndet ()
+        for ifrag in np.where (idx)[0]:
+            self.ci[ifrag] = np.append (
+                np.asarray (self.ci[ifrag]).reshape (-1, ndet[ifrag][0], ndet[ifrag][1]),
+                np.asarray (other.ci[ifrag]).reshape (-1, ndet[ifrag][0], ndet[ifrag][1]),
+                axis=0
+            )
+            ovlp = np.tensordot (self.ci[ifrag].conj (), self.ci[ifrag],
+                                 axes=((1,2),(1,2)))
+            if linalg.det (ovlp) < LINDEP_THRESH:
+                evals, evecs = linalg.eigh (ovlp)
+                idx = evals>LINDEP_THRESH
+                evals, evecs = evals[idx], evecs[:,idx]
+                evecs /= np.sqrt (evals)[None,:]
+                self.ci[ifrag] = np.tensordot (evecs.T, self.ci[ifrag], axes=1)
+
+def orthogonal_excitations (exc1, exc2, ref):
+    if exc1.nfrag != ref.nfrag: return False
+    if exc2.nfrag != ref.nfrag: return False
+    idx1 = exc1.excited_fragments (ref)
+    if not np.count_nonzero (idx1): return False
+    idx2 = exc2.excited_fragments (ref)
+    if not np.count_nonzero (idx2): return False
+    if np.count_nonzero (idx1 & idx2): return False
+    return True
+
+def combine_orthogonal_excitations (exc1, exc2, ref):
+    nfrag = ref.nfrag
+    spins = exc1.spins.copy ()
+    smults = exc1.smults.copy ()
+    charges = exc1.charges.copy ()
+    idx2 = exc2.excited_fragments (ref)
+    spins[idx2] = exc2.spins[idx2]
+    smults[idx2] = exc2.smults[idx2]
+    charges[idx2] = exc2.charges[idx2]
+    ci = None
+    if exc1.has_ci () and exc2.has_ci ():
+        ci = [exc2.ci[ifrag] if idx2[ifrag] else exc1.ci[ifrag] for ifrag in range (nfrag)]
+    product = SingleLASRootspace (
+        ref.las, spins, smults, charges, 0, ci=ci,
+        nlas=ref.nlas, nelelas=ref.nelelas, stdout=ref.stdout, verbose=ref.verbose
+    )
+    product.entmap = tuple (set (exc1.entmap + exc2.entmap))
+    #assert (np.amax (product.entmap) < 2)
+    assert (len (product.entmap) == len (set (product.entmap)))
+    for ifrag in range (nfrag):
+        assert ((product.ci[ifrag] is exc1.ci[ifrag]) or
+                (product.ci[ifrag] is exc2.ci[ifrag]) or
+                (product.ci[ifrag] is ref.ci[ifrag]))
+    return product
 
 def all_single_excitations (las, verbose=None):
     '''Add states characterized by one electron hopping from one fragment to another fragment
@@ -362,16 +433,16 @@ def all_single_excitations (las, verbose=None):
         new_states.extend (ref_state.get_singles ())
     seen = set (ref_states)
     all_states = ref_states + [state for state in new_states if not ((state in seen) or seen.add (state))]
-    weights = [state.weight for state in all_states]
-    charges = [state.charges for state in all_states]
-    spins = [state.spins for state in all_states]
-    smults = [state.smults for state in all_states]
-    #wfnsyms = [state.wfnsyms for state in all_states]
     log.info ('Built {} singly-excited LAS states from {} reference LAS states'.format (
         len (all_states) - len (ref_states), len (ref_states)))
     if len (all_states) == len (ref_states):
         log.warn (("%d reference LAS states exhaust current active space specifications; "
                    "no singly-excited states could be constructed"), len (ref_states))
+    weights = [state.weight for state in all_states]
+    charges = [state.charges for state in all_states]
+    spins = [state.spins for state in all_states]
+    smults = [state.smults for state in all_states]
+    #wfnsyms = [state.wfnsyms for state in all_states]
     return las.state_average (weights=weights, charges=charges, spins=spins, smults=smults)
 
 def spin_shuffle (las, verbose=None, equal_weights=False):
@@ -390,16 +461,8 @@ def spin_shuffle (las, verbose=None, equal_weights=False):
         raise NotImplementedError ("Point-group symmetry for LASSI state generator")
     ref_states = [SingleLASRootspace (las, m, s, c, 0) for c,m,s,w in zip (*get_space_info (las))]
     for weight, state in zip (las.weights, ref_states): state.weight = weight
-    seen = set (ref_states)
-    all_states = [state for state in ref_states]
-    for ref_state in ref_states:
-        for new_state in ref_state.gen_spin_shuffles ():
-            if not new_state in seen:
-                all_states.append (new_state)
-                seen.add (new_state)
+    all_states = _spin_shuffle (ref_states, equal_weights=equal_weights)
     weights = [state.weight for state in all_states]
-    if equal_weights:
-        weights = [1.0/len(all_states),]*len(all_states)
     charges = [state.charges for state in all_states]
     spins = [state.spins for state in all_states]
     smults = [state.smults for state in all_states]
@@ -409,6 +472,19 @@ def spin_shuffle (las, verbose=None, equal_weights=False):
     if len (all_states) == len (ref_states):
         log.warn ("no spin-shuffling options found for given LAS states")
     return las.state_average (weights=weights, charges=charges, spins=spins, smults=smults)
+
+def _spin_shuffle (ref_spaces, equal_weights=False):
+    seen = set (ref_spaces)
+    all_spaces = [space for space in ref_spaces]
+    for ref_space in ref_spaces:
+        for new_space in ref_space.gen_spin_shuffles ():
+            if not new_space in seen:
+                all_spaces.append (new_space)
+                seen.add (new_space)
+    if equal_weights:
+        w = 1.0/len(all_spaces)
+        for space in all_spaces: space.weight = w
+    return all_spaces
 
 def spin_shuffle_ci (las, ci):
     '''Fill out the CI vectors for rootspaces constructed by the spin_shuffle function.
@@ -421,19 +497,26 @@ def spin_shuffle_ci (las, ci):
     from mrh.my_pyscf.mcscf.lasci import get_space_info
     spaces = [SingleLASRootspace (las, m, s, c, 0, ci=[c[ix] for c in ci])
               for ix, (c, m, s, w) in enumerate (zip (*get_space_info (las)))]
+    spaces = _spin_shuffle_ci_(spaces)
+    ci = [[space.ci[ifrag] for space in spaces] for ifrag in range (las.nfrags)]
+    return ci
+
+def _spin_shuffle_ci_(spaces):
     old_ci_sz = []
     old_idx = []
     new_idx = []
-    nfrag = las.nfrags
+    nfrag = spaces[0].nfrag
     for ix, space in enumerate (spaces):
         if space.has_ci ():
             old_idx.append (ix)
             old_ci_sz.append (space.get_ci_szrot ())
         else:
             new_idx.append (ix)
+            space.ci = [None for ifrag in range (space.nfrag)]
     def is_spin_shuffle_ref (sp1, sp2):
         return (np.all (sp1.charges==sp2.charges) and
-                np.all (sp1.smults==sp2.smults))
+                np.all (sp1.smults==sp2.smults) and
+                sp1.entmap==sp2.entmap)
     for ix in new_idx:
         ndet = spaces[ix].get_ndet ()
         ci_ix = [np.zeros ((0,ndet[i][0],ndet[i][1]))
@@ -446,7 +529,7 @@ def spin_shuffle_ci (las, ci):
                 ci_ix[ifrag] = np.append (ci_ix[ifrag], c, axis=0)
         for ifrag in range (nfrag):
             if ci_ix[ifrag].size==0:
-                ci[ifrag][ix] = None
+                spaces[ix].ci[ifrag] = None
                 continue
             lroots, ndeti = ci_ix[ifrag].shape[0], ndet[ifrag]
             if lroots > 1:
@@ -457,8 +540,8 @@ def spin_shuffle_ci (las, ci):
                 v = v[:,idx] / np.sqrt (w[idx])[None,:]
                 c = (c @ v).T
                 ci_ix[ifrag] = c.reshape (-1, ndeti[0], ndeti[1])
-            ci[ifrag][ix] = ci_ix[ifrag]
-    return ci
+            spaces[ix].ci[ifrag] = ci_ix[ifrag]
+    return spaces
 
 def count_excitations (las0):
     log = logger.new_logger (las0, las0.verbose)

--- a/my_pyscf/mcscf/lasci_sync.py
+++ b/my_pyscf/mcscf/lasci_sync.py
@@ -1125,26 +1125,26 @@ class LASCI_HessianOperator (sparse_linalg.LinearOperator):
         # Don't ask my why this is faster than doing the two degrees of freedom separately...
         t1 = lib.logger.timer (self.las, 'vk_mo vPpj in microcycle', *t1)
 
-        if gpu:
-            naux = self.bPpj.shape[0]
-            vk_bj = np.zeros( (nmo-ncore, nocc) )
-            libgpu.libgpu_hessop_get_veff(gpu, naux, nmo, ncore, nocc, self.bPpj, vPpj, vk_bj)
-            t1 = lib.logger.timer (self.las, 'vk_mo (bb|jj) in microcycle', *t1)   
-            t1 = lib.logger.timer (self.las, 'vk_mo (bi|aj) in microcycle', *t1);
+        #if gpu:
+        #    naux = self.bPpj.shape[0]
+        #    vk_bj = np.zeros( (nmo-ncore, nocc) )
+        #    libgpu.libgpu_hessop_get_veff(gpu, naux, nmo, ncore, nocc, self.bPpj, vPpj, vk_bj)
+        #    t1 = lib.logger.timer (self.las, 'vk_mo (bb|jj) in microcycle', *t1)   
+        #    t1 = lib.logger.timer (self.las, 'vk_mo (bi|aj) in microcycle', *t1);
 
-        else: 
-            # vk (aa|ii), (uv|xy), (ua|iv), (au|vi)
-            vPbj = vPpj[:,ncore:,:] #np.dot (self.bPpq[:,ncore:,ncore:], dm_ai)
-            vk_bj = np.tensordot (vPbj, self.bPpj[:,:nocc,:], axes=((0,2),(0,1)))
-            t1 = lib.logger.timer (self.las, 'vk_mo (bb|jj) in microcycle', *t1)
-            # vk (ai|ai), (ui|av)
-            dm_ai = dm1_mo[nocc:,:ncore]
-            vPji = vPpj[:,:nocc,:ncore] #np.dot (self.bPpq[:,:nocc, nocc:], dm_ai)
-            # I think this works only because there is no dm_ui in this case, so I've eliminated all
-            # the dm_uv by choosing this range
-            bPbi = self.bPpj[:,ncore:,:ncore]
-            vk_bj += np.tensordot (bPbi, vPji, axes=((0,2),(0,2)))                    
-            t1 = lib.logger.timer (self.las, 'vk_mo (bi|aj) in microcycle', *t1)
+        #else: 
+        # vk (aa|ii), (uv|xy), (ua|iv), (au|vi)
+        vPbj = vPpj[:,ncore:,:] #np.dot (self.bPpq[:,ncore:,ncore:], dm_ai)
+        vk_bj = np.tensordot (vPbj, self.bPpj[:,:nocc,:], axes=((0,2),(0,1)))
+        t1 = lib.logger.timer (self.las, 'vk_mo (bb|jj) in microcycle', *t1)
+        # vk (ai|ai), (ui|av)
+        dm_ai = dm1_mo[nocc:,:ncore]
+        vPji = vPpj[:,:nocc,:ncore] #np.dot (self.bPpq[:,:nocc, nocc:], dm_ai)
+        # I think this works only because there is no dm_ui in this case, so I've eliminated all
+        # the dm_uv by choosing this range
+        bPbi = self.bPpj[:,ncore:,:ncore]
+        vk_bj += np.tensordot (bPbi, vPji, axes=((0,2),(0,2)))                    
+        t1 = lib.logger.timer (self.las, 'vk_mo (bi|aj) in microcycle', *t1)
 
         # veff
         vj_bj = vj_pj[ncore:,:]

--- a/my_pyscf/mcscf/lasci_sync.py
+++ b/my_pyscf/mcscf/lasci_sync.py
@@ -523,6 +523,7 @@ def _init_df_(h_op):
             if gpu:
                 libgpu.libgpu_hessop_push_bPpj(gpu, h_op.bPpj)
 
+# TODO: local state-average generalization
 class LASCI_HessianOperator (sparse_linalg.LinearOperator):
     ''' The Hessian-vector product for a `LASCI' energy minimization, implemented as a linear
     operator from the scipy.sparse.linalg module. `LASCI' here means that the CAS is frozen

--- a/my_pyscf/mcscf/lasscf_rdm.py
+++ b/my_pyscf/mcscf/lasscf_rdm.py
@@ -219,6 +219,7 @@ def kernel (las, mo_coeff=None, casdm1frs=None, casdm2fr=None, conv_tol_grad=1e-
         if ((norm_gorb < conv_tol_grad) or (norm_gorb < norm_gx/10)) and rdmjk_conv:
             converged = True
             break
+        las.dump_chk (mo_coeff=mo_coeff, ci=[casdm1frs, casdm2fr])
         H_op._init_eri_() # Take this part out of the true initialization b/c 
                           # if I'm already converged I don't want to waste the cycles
         t1 = log.timer ('LASSCF Hessian constructor', *t1)
@@ -370,7 +371,6 @@ class RDMSolver (lib.StreamObject):
         return (h1s, h2)
 
     def get_init_guess (self, norb, nelec, nroots, ham):
-        ''' Important: zeroth item selected in get_init_guess_ci '''
         h1s, h2 = ham
         if callable (self._get_init_guess):
             dm1s, dm2 = self._get_init_guess (norb, nelec, nroots, h1s, h2)
@@ -379,7 +379,7 @@ class RDMSolver (lib.StreamObject):
             hdiag = fci.make_hdiag_csf (h1s, h2, norb, nelec)
             ci = fci.get_init_guess (norb, nelec, nroots, hdiag)
             dm1s, dm2 = self._ci2rdm (fci, ci, norb, nelec)
-        return [dm1s, dm2], None
+        return dm1s, dm2
 
     def kernel (self, norb, nelec, h0, h1s, h2):
         h2 = ao2mo.restore (1, h2, norb)
@@ -448,6 +448,15 @@ def make_fcibox (mol, kernel=None, get_init_guess=None, spin=None):
     s.spin = spin
     return FCIBox ([s])
 
+def _combine_init_guess_ci (las, ci0i, ci0g, norb, nelec, nroots):
+    if nroots>1: raise NotImplementedError ("Multiple local roots for lasscf_rdm")
+    if getattr (ci0i, '__len__', None) is None: return ci0g
+    if len (ci0i) != 2: return ci0g
+    for n, ci0in in enumerate (ci0i):
+        if not isinstance (ci0in, np.ndarray): return ci0g
+        if ci0in.size != norb ** (2*n): return ci0g
+    return ci0i
+
 class LASSCFNoSymm (lasscf_sync_o0.LASSCFNoSymm):
 
     def __init__(self, *args, **kwargs):
@@ -462,6 +471,7 @@ class LASSCFNoSymm (lasscf_sync_o0.LASSCFNoSymm):
     _ugg = LASSCF_UnitaryGroupGenerators
     _hop = LASSCF_HessianOperator
     canonicalize = canonicalize
+    _combine_init_guess_ci = _combine_init_guess_ci
 
     def _init_fcibox (self, smult, nel):
         return make_fcibox (self.mol, spin=nel[0]-nel[1])

--- a/my_pyscf/mcscf/lasscf_sync_o0.py
+++ b/my_pyscf/mcscf/lasscf_sync_o0.py
@@ -169,7 +169,14 @@ class LASSCFNoSymm (lasci.LASCINoSymm):
         return veff
     def dump_flags (self, verbose=None, _method_name='LASSCF'):
         lasci.LASCINoSymm.dump_flags (self, verbose=verbose, _method_name=_method_name)
+    #SV
+    def nuc_grad_method(self):
+        from mrh.my_pyscf.grad import lasscf
+        return lasscf.Gradients(self)
 
+    #SV
+    Gradients = nuc_grad_method
+    
 class LASSCFSymm (lasci.LASCISymm):
     _ugg = LASSCFSymm_UnitaryGroupGenerators    
     _hop = LASSCF_HessianOperator

--- a/my_pyscf/mcscf/productstate.py
+++ b/my_pyscf/mcscf/productstate.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy import linalg
 from pyscf import lib
+from pyscf.scf.addons import canonical_orth_
 from pyscf.fci import cistring
 from pyscf.mcscf.addons import state_average as state_average_mcscf
 from mrh.my_pyscf.fci.csf import CSFFCISolver
@@ -30,10 +31,12 @@ class ProductStateFCISolver (StateAverageNMixFCISolver, lib.StreamObject):
         converged = False
         e_sigma = 0
         e = [0 for n in norb_f]
-        ci1 = self.get_init_guess (ci0, norb_f, nelec_f, h1, h2)
+        ci1 = ci0
         log.info ('Entering product-state fixed-point CI iteration')
         for it in range (max_cycle_macro):
-            ci0 = ci1
+            ci0 = self.get_init_guess (ci1, norb_f, nelec_f, h1, h2)
+            # Issue #86: put get_init_guess INSIDE the iteration in case _1shot below encounters
+            # linear dependencies and can't populate all CI vectors for all fragments.
             h1eff, h0eff, ci0 = self.project_hfrag (h1, h2, ci0, norb_f, nelec_f,
                 ecore=ecore, **kwargs)
             grad = self._get_grad (h1eff, h2, ci0, norb_f, nelec_f, **kwargs)
@@ -55,12 +58,35 @@ class ProductStateFCISolver (StateAverageNMixFCISolver, lib.StreamObject):
         conv_str = ['NOT converged','converged'][int (converged)]
         log.info (('Product_state fixed-point CI iteration {} after {} '
                    'cycles').format (conv_str, it))
-        if not converged: self._debug_csfs (log, ci0, ci1, norb_f, nelec_f, grad)
+        if not converged:
+            ci1 = self.get_init_guess (ci1, norb_f, nelec_f, h1, h2)
+            # Issue #86: see above, same problem
+            self._debug_csfs (log, ci0, ci1, norb_f, nelec_f, grad)
         energy_elec = self.energy_elec (h1, h2, ci1, norb_f, nelec_f,
             ecore=ecore, **kwargs)
         return converged, energy_elec, ci1
 
     def get_init_guess (self, ci0, norb_f, nelec_f, h1, h2):
+        '''Generate CI guess vectors for all fragments.
+
+        Args:
+            ci0: list of length nfrag or None
+                Contains either None or ndarrays of guess CI vectors. Any new guess CI vectors
+                constructed by this function are constrained to be orthogonal to those already
+                provided here, if any.
+            norb_f: list of length nfrag of integers
+                Number of orbitals in each fragment
+            nelec_f: list of length nfrag of integers
+                Number of electrons (in reference state) in each fragment
+            h1: ndarray of shape (ncas,ncas) or (2,ncas,ncas)
+                One-electron Hamiltonian amplitudes
+            h2: ndarray of shape (ncas,ncas,ncas,ncas)
+                Two-electron Hamiltonian amplitudes
+
+        Returns:
+            ci1: list of length nfrag of ndarrays
+                Orthonormal guess CI vectors. Any vectors present in ci0 are preserved unaltered.
+        '''
         if ci0 is None: ci0 = [None for i in range (len (norb_f))]
         ci1 = [c for c in ci0] # reference safety
         if h1.ndim < 3: h1 = np.stack ([h1, h1], axis=0)
@@ -78,13 +104,21 @@ class ProductStateFCISolver (StateAverageNMixFCISolver, lib.StreamObject):
             elif np.asarray (ci1[ix]).reshape (-1,na*nb).shape[0] < solver.nroots:
                 ci1_inp = np.asarray (ci1[ix]).reshape (-1,na*nb)
                 ci1_guess = np.asarray (ci1_guess).reshape (-1,na*nb)
-                ovlp = ci1_inp.conj () @ ci1_guess.T
-                ci1_guess -= ovlp @ ci1_guess
-                ovlp = ci1_guess.conj () @ ci1_guess.T
-                Q, R = linalg.qr (ovlp)
-                ci1_guess = Q.T @ ci1_guess
-                ci1[ix] = np.append (ci1_inp, ci1_guess, axis=0)[:solver.nroots].reshape (
-                    solver.nroots, na, nb)
+                x = np.append (ci1_inp, ci1_guess, axis=0)
+                x = canonical_orth_(x.conj () @ x.T).T @ x
+                # ^ an orthonormal basis
+                assert (x.shape[0] >= solver.nroots)
+                x2inp = x.conj () @ ci1_inp.T
+                ninp = ci1_inp.shape[0]
+                u, svals, vh = linalg.svd (x2inp, full_matrices=True)
+                u[:,:ninp] = u[:,:ninp] @ vh
+                ci1_new = u.T @ x
+                nnew = ci1_new.shape[0]
+                ovlp = ci1_new.conj () @ ci1_inp.T
+                assert (np.all (np.abs (ovlp[:ninp,:ninp] - np.eye (ninp)) < 1e-6)), '{}'.format (ovlp)
+                ovlp = (ci1_new.conj () @ ci1_new.T)
+                assert (np.all (np.abs (ovlp - np.eye (nnew)) < 1e-6)), '{}'.format (ovlp)
+                ci1[ix] = ci1_new[:solver.nroots].reshape (solver.nroots, na, nb)
         return self._check_init_guess (ci1, norb_f, nelec_f)
 
     def _check_init_guess (self, ci0, norb_f, nelec_f):

--- a/my_pyscf/tools/molden.py
+++ b/my_pyscf/tools/molden.py
@@ -41,9 +41,13 @@ def from_si_mcscf (mc, fname, state=None, si=None, cas_natorb=False, cas_mo_ener
         return from_sa_mcscf (mc, fname, state=state, cas_natorb=cas_natorb,
                               cas_mo_energy=cas_mo_energy, **kwargs)
 
-def from_lasscf (las, fname, state=None, natorb_casdm1=None, **kwargs):
+def from_lasscf (las, fname, state=None, natorb_casdm1=None, only_as=False, **kwargs):
     if state is not None: natorb_casdm1 = las.states_make_casdm1s ()[state].sum (0)
     mo_coeff, mo_ene, mo_occ = las.canonicalize (natorb_casdm1=natorb_casdm1)[:3]
+    if only_as:
+        mo_coeff = mo_coeff[:, las.ncore:las.ncore+las.ncas]
+        mo_ene = mo_ene[las.ncore:las.ncore+las.ncas]
+        mo_occ = mo_occ[las.ncore:las.ncore+las.ncas]
     return from_mo (las.mol, fname, mo_coeff, occ=mo_occ, ene=mo_ene, **kwargs)
 
 def from_lassi (lsi, fname, state=0, si=None, opt=1, **kwargs):

--- a/pyscf-forge_version.txt
+++ b/pyscf-forge_version.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pyscf/pyscf-forge.git@53511781bd27f294a4ae53477acabf94fb9e930f
+git+https://github.com/pyscf/pyscf-forge.git@6fa7530498f434404a323bd7b116a04d8f7c1f12

--- a/pyscf_version.txt
+++ b/pyscf_version.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pyscf/pyscf.git@d3f622d46eef5d9b8702fa6f4577babfb6c2ccfe
+git+https://github.com/pyscf/pyscf.git@940e4ac16f02eeef3fc944eae190d7f0609a60e7

--- a/tests/lasscf/test_lasscf_rdm.py
+++ b/tests/lasscf/test_lasscf_rdm.py
@@ -20,16 +20,20 @@ from pyscf import lib, gto, scf
 from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF as LASSCFRef
 from mrh.my_pyscf.mcscf.lasscf_rdm import LASSCF as LASSCFTest
 
-xyz = '''H 0.0 0.0 0.0
-         H 1.0 0.0 0.0
-         H 0.2 3.9 0.1
-         H 1.159166 4.1 -0.1'''
-mol = gto.M (atom = xyz, basis = '6-31g', output='lasscf_rdm.log',
-    verbose=lib.logger.INFO)
-mf = scf.RHF (mol).run ()
-las_ref = LASSCFRef (mf, (2,2), (2,2), spin_sub=(1,1))
-las_test = LASSCFTest (mf, (2,2), (2,2), spin_sub=(1,1))
-mo_loc = las_ref.localize_init_guess (((0,1),(2,3)), mf.mo_coeff)
+def setUpModule():
+    global mol, mf, las_test, las_ref, mo_loc
+    xyz = '''H 0.0 0.0 0.0
+             H 1.0 0.0 0.0
+             H 0.2 3.9 0.1
+             H 1.159166 4.1 -0.1'''
+    mol = gto.M (atom = xyz, basis = '6-31g', output='lasscf_rdm.log',
+        verbose=lib.logger.INFO)
+    mf = scf.RHF (mol).run ()
+    las_ref = LASSCFRef (mf, (2,2), (2,2), spin_sub=(1,1))
+    las_ref.chkfile = 'lasscf_rdm_ref.chk'
+    las_test = LASSCFTest (mf, (2,2), (2,2), spin_sub=(1,1))
+    las_test.chkfile = 'lasscf_rdm_test.chk'
+    mo_loc = las_ref.localize_init_guess (((0,1),(2,3)), mf.mo_coeff)
 
 def tearDownModule():
     global mol, mf, las_test, las_ref, mo_loc

--- a/tests/lasscf/test_utilities.py
+++ b/tests/lasscf/test_utilities.py
@@ -11,7 +11,7 @@ class KnownValues (unittest.TestCase):
 
     def test_get_single_state_las (self):
         from mrh.my_pyscf.mcscf.lasscf_async import LASSCF
-        from mrh.my_pyscf.lassi import states as lassi_states
+        from mrh.my_pyscf.lassi import spaces as lassi_spaces
         xyz='''N 0 0 0,
                N 3 0 0'''
         mol = gto.M (atom=xyz, basis='cc-pvdz', symmetry=False, verbose=0, output='/dev/null')
@@ -19,7 +19,7 @@ class KnownValues (unittest.TestCase):
         las = LASSCF (mf, (6,6), ((3,0),(0,3)))
         
         mo = las.set_fragments_(([0],[1]))
-        las = lassi_states.spin_shuffle (las)
+        las = lassi_spaces.spin_shuffle (las)
         las.weights = [1.0/las.nroots,]*las.nroots
         las.kernel (mo)
         for i in range (len (las.e_states)):

--- a/tests/lasscf_nucgrad/test_grad_lasscf.py
+++ b/tests/lasscf_nucgrad/test_grad_lasscf.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Author: Shreya Verma <shreyav@uchicago.edu>
+
+# The following tests are broken down into a couple of different categories.
+#   1. Check accuracy of LASSCF analytical gradients with single fragment to CASSCF gradients for a diatomic molecule.
+#   2. Check the implemmentation as scanner object.
+
+import unittest
+
+from pyscf import scf, gto, df, lib
+from pyscf import mcscf
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
+import numpy as np
+
+
+def diatomic(atom1, atom2, r, basis, ncas, nelecas, charge=None, spin=None, cas_irrep=None, density_fit=False):
+    """Used for checking diatomic systems to see if the Lagrange Multipliers are working properly."""
+    global mols
+    xyz = '{:s} 0.0 0.0 0.0; {:s} {:.3f} 0.0 0.0'.format(atom1, atom2, r)
+    mol = gto.M(atom=xyz, basis=basis, charge=charge, spin=spin, verbose=0, output='/dev/null')
+    mols.append(mol)
+    mf = scf.RHF(mol)
+
+    mc = mcscf.CASSCF(mf.run(), ncas, nelecas)
+    if spin is None:
+        spin = mol.nelectron % 2
+
+    ss = spin * (spin + 2) * 0.25
+    mo = mc.mo_coeff
+    #mc = mc.multi_state([1.0 / float(nstates), ] * nstates, 'lin')
+    mc.fix_spin_(ss=ss)
+    #mc.conv_tol = 1e-12
+    #mc.conv_grad_tol = 1e-6
+    #mo = None
+
+    mc_grad = mc.run(mo).nuc_grad_method()
+    #mc_grad.conv_rtol = 1e-12
+
+    las = LASSCF (mf,(2,),(2,), spin_sub=(1))
+    frag_atom_list = [list (range (2))]
+    mo_coeff = las.localize_init_guess (frag_atom_list, mf.mo_coeff)
+    las.kernel (mo_coeff)
+    #las_grad = las.Gradients()
+    las_grad = las.nuc_grad_method()
+
+    return mc_grad,las_grad
+
+
+def setUpModule():
+    global mols
+    mols = []
+
+
+def tearDownModule():
+    global mols, diatomic
+    [m.stdout.close() for m in mols]
+    del mols, diatomic
+
+
+class KnownValues(unittest.TestCase):
+
+    def test_grad_h2_sto3g(self):
+        mc_grad,las_grad = diatomic('H', 'H', 1.0, 'sto-3g', 2, 2)
+
+        de_las = las_grad.kernel()
+        de_cas = mc_grad.kernel()
+
+        self.assertAlmostEqual (lib.fp (de_cas), lib.fp (de_las), 6)
+
+    def test_grad_scanner(self):
+        # Tests and Scanner capabilities
+        mc_grad1, las_grad1 = diatomic('H', 'H', 1.0, 'sto-3g', 2, 2)
+        mol1 = mc_grad1.base.mol
+        mc_grad2, las_grad2 = diatomic('H', 'H', 1.0, 'sto-3g', 2, 2)
+        las_grad2 = las_grad2.as_scanner()
+        de1 = las_grad1.kernel()
+        e1 = las_grad1.base.e_states[0]
+        e2, de2 = las_grad2(mol1)
+        self.assertAlmostEqual(e1, e2, 6)
+        self.assertAlmostEqual(lib.fp(de1), lib.fp(de2), 6)
+
+
+if __name__ == "__main__":
+    print("Full Tests for LASSCF gradients")
+    unittest.main()

--- a/tests/lassi/test_22.py
+++ b/tests/lassi/test_22.py
@@ -20,7 +20,7 @@ from pyscf import lib, gto, scf, mcscf, ao2mo
 from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
 from mrh.my_pyscf.lassi import LASSI, LASSIrq, LASSIrqCT
 from mrh.my_pyscf.lassi.lassi import root_make_rdm12s, make_stdm12s
-from mrh.my_pyscf.lassi.states import all_single_excitations, SingleLASRootspace
+from mrh.my_pyscf.lassi.spaces import all_single_excitations, SingleLASRootspace
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 from mrh.my_pyscf.lassi import op_o0, op_o1, lassis
 

--- a/tests/lassi/test_c2h4n4.py
+++ b/tests/lassi/test_c2h4n4.py
@@ -122,7 +122,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual (e1, e0, 8)
 
     def test_singles_constructor (self):
-        from mrh.my_pyscf.lassi.states import all_single_excitations
+        from mrh.my_pyscf.lassi.spaces import all_single_excitations
         las2 = all_single_excitations (lsi._las)
         las2.check_sanity ()
         # Meaning of tuple: (na+nb,smult)
@@ -135,7 +135,7 @@ class KnownValues(unittest.TestCase):
         self.assertEqual (las2.nroots, 33)
 
     def test_spin_shuffle (self):
-        from mrh.my_pyscf.lassi.states import spin_shuffle, spin_shuffle_ci
+        from mrh.my_pyscf.lassi.spaces import spin_shuffle, spin_shuffle_ci
         mf = lsi._las._scf
         las3 = spin_shuffle (las)
         las3.check_sanity ()
@@ -181,7 +181,7 @@ class KnownValues(unittest.TestCase):
         for opt in (0,1):
             with self.subTest (opt=opt):
                 lsis = LASSIS (las1).run (opt=opt)
-                self.assertAlmostEqual (lsis.e_roots[0], -295.52103116343307, 7)
+                self.assertAlmostEqual (lsis.e_roots[0], -295.5210783894406, 7)
                 self.assertTrue (lsis.converged)
 
 if __name__ == "__main__":

--- a/tests/lassi/test_citools.py
+++ b/tests/lassi/test_citools.py
@@ -1,0 +1,65 @@
+import copy
+import unittest
+import numpy as np
+from scipy import linalg
+from mrh.my_pyscf.lassi import citools
+from pyscf import lib
+from pyscf.scf.addons import canonical_orth_
+import itertools
+
+def setUpModule():
+    pass
+
+def tearDownModule():
+    pass
+
+def case_umat_dot_1frag (ks, rng, nroots, nfrags, nvecs, lroots):
+    nstates = np.product (lroots, axis=0).sum ()
+    if nvecs > nstates: return
+    si = np.empty ((0,0))
+    for i in range (100):
+        si = rng.random (size=(nstates,nvecs))
+        si = si @ canonical_orth_(si.conj ().T @ si)
+        if si.shape[1] == nvecs: break
+    ks.assertEqual (si.shape[1], nvecs)
+    si0 = si.copy ()
+    UUsi = si.copy ()
+    siT = si.T.copy ()
+    UUsiT = siT.copy ()
+    for ifrag, iroot in itertools.product (range (nfrags), range (nroots)):
+        lr = lroots[ifrag,iroot]
+        umat = linalg.qr (rng.random (size=(lr,lr)))[0]
+        #umat = umat @ canonical_orth_(umat.conj ().T @ umat)
+        ks.assertEqual (umat.shape[1], lr)
+        ks.assertAlmostEqual (lib.fp (umat.conj ().T @ umat), lib.fp (np.eye (lr)))
+        ks.assertAlmostEqual (lib.fp (umat @ umat.conj ().T), lib.fp (np.eye (lr)))
+        si = citools.umat_dot_1frag_(si, umat, lroots, ifrag, iroot, axis=0)
+        UUsi = citools.umat_dot_1frag_(UUsi, umat, lroots, ifrag, iroot, axis=0)
+        UUsi = citools.umat_dot_1frag_(UUsi, umat.conj ().T, lroots, ifrag, iroot, axis=0)
+        siT = citools.umat_dot_1frag_(siT, umat, lroots, ifrag, iroot, axis=1)
+        UUsiT = citools.umat_dot_1frag_(UUsiT, umat, lroots, ifrag, iroot, axis=1)
+        UUsiT = citools.umat_dot_1frag_(UUsiT, umat.conj ().T, lroots, ifrag, iroot, axis=1)
+    ovlp = si.conj ().T @ si
+    ovlpT = siT.conj () @ siT.T
+    ks.assertAlmostEqual (lib.fp (ovlp), lib.fp (np.eye (nvecs)))
+    ks.assertAlmostEqual (lib.fp (ovlpT), lib.fp (np.eye (nvecs)))
+    ks.assertAlmostEqual (lib.fp (UUsi), lib.fp (si0))
+    ks.assertAlmostEqual (lib.fp (UUsiT), lib.fp (si0.conj ().T))
+    return
+
+class KnownValues(unittest.TestCase):
+
+    def test_umat_dot_1frag (self):
+        rng = np.random.default_rng ()
+        nroots, nfrags, nvecs = tuple (rng.integers (1, high=6, size=3))
+        for nroots, nfrags, nvecs in itertools.product (range (1,6), repeat=3):
+            lroots = rng.integers (1, high=10, size=(nfrags,nroots))
+            with self.subTest (nroots=nroots, nfrags=nfrags, nvecs=nvecs, lroots=lroots):
+                case_umat_dot_1frag (self, rng, nroots, nfrags, nvecs, lroots)
+
+
+if __name__ == "__main__":
+    print("Full Tests for LASSI citools module functions")
+    unittest.main()
+
+

--- a/tests/lassi/test_excitations.py
+++ b/tests/lassi/test_excitations.py
@@ -23,7 +23,7 @@ from mrh.my_pyscf.fci import csf_solver
 from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
 from mrh.my_pyscf.lassi import LASSI, op_o0, op_o1
 from mrh.my_pyscf.lassi.lassi import root_make_rdm12s, make_stdm12s
-from mrh.my_pyscf.lassi.states import all_single_excitations
+from mrh.my_pyscf.lassi.spaces import all_single_excitations
 from mrh.my_pyscf.lassi.excitations import ExcitationPSFCISolver
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 from mrh.my_pyscf.mcscf.productstate import ImpureProductStateFCISolver

--- a/tests/lassi/test_opt57_slow.py
+++ b/tests/lassi/test_opt57_slow.py
@@ -108,7 +108,15 @@ def setUpModule ():
             ndet_s = ndet_frs[ifrag,iroot]
             ci = np.random.rand (lroots_r, ndet_s[0], ndet_s[1])
             ci /= linalg.norm (ci.reshape (lroots_r,-1), axis=1)[:,None,None]
-            if lroots_r==1: ci=ci[0]
+            if lroots_r==1:
+                ci=ci[0]
+            else:
+                ci = ci.reshape (lroots_r,-1)
+                w, v = linalg.eigh (ci.conj () @ ci.T)
+                idx = w > 0
+                w, v = w[idx], v[:,idx]
+                v /= np.sqrt (w)[None,:]
+                ci = np.dot (v.T, ci).reshape (lroots_r, ndet_s[0], ndet_s[1])
             las.ci[ifrag][iroot] = ci
     orbsym = getattr (las.mo_coeff, 'orbsym', None)
     if orbsym is None and callable (getattr (las, 'label_symmetry_', None)):

--- a/tests/mcpdft/test_lassipdft.py
+++ b/tests/mcpdft/test_lassipdft.py
@@ -2,7 +2,7 @@ import unittest
 from pyscf import lib, gto, scf
 from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
 from mrh.my_pyscf.lassi import LASSI
-from mrh.my_pyscf.lassi.states import all_single_excitations
+from mrh.my_pyscf.lassi.spaces import all_single_excitations
 from mrh.my_pyscf.mcscf.lasci import get_space_info
 
 class KnownValues(unittest.TestCase):


### PR DESCRIPTION
* Merged with latest dev
* Some "light" tuning of get_jk() CUDA kernels (light because need straightforward port to portable programming model)
* Added mini-app for evaluating tall-skinny matrix transposes
* Updated Makefile and arch files to support mini-app builds
* Enabled "not with_k" branch in get_jk()
* Added exploratory code to bypass dfobj.loop() copy ; not needed at moment
* Added support for per-device streams and handles
* Added multi-gpu support for get_jk()
* Temporarily disabled gpu-offload of hessop_get_veff because of issue with multi-gpu support
* Added OpenMP thread affinity info to output
* Updated arch and builds after Polaris@ALCF software upgrade