### PR TITLE
LASCI at gamma point

### DIFF
--- a/examples/pbc/lasci_gamma_point.py
+++ b/examples/pbc/lasci_gamma_point.py
@@ -22,6 +22,8 @@ Probably that's the reason of slow convergence!
 mol = gto.M(atom = '''
     H         -6.37665        2.20769        0.00000
     H         -5.81119        2.63374       -0.00000
+    H         -6.37665        2.20769        2.00000
+    H         -5.81119        2.63374        2.00000
     ''',
     basis = '631g',
     verbose = 4,max_memory=10000)
@@ -29,11 +31,11 @@ mol = gto.M(atom = '''
 mf = scf.RHF(mol)
 memf = mf.kernel()
 
-mc = mcscf.CASCI(mf, 2, 2)
+mc = mcscf.CASCI(mf, 4, 4)
 mecasci = mc.kernel()[0]
 
-las = LASSCF(mf, (2,), (2,))
-mo0 = las.localize_init_guess((list(range(2)),))
+las = LASSCF(mf, (2,2), (2,2))
+mo0 = las.localize_init_guess((list(range(2)), list(range(2, 4))))
 melasci = las.lasci(mo0)
 
 del mol, mf, mc, las
@@ -46,6 +48,8 @@ def cellObject(x):
     atom = '''
     H         -6.37665        2.20769        0.00000
     H         -5.81119        2.63374       -0.00000
+    H         -6.37665        2.20769        2.00000
+    H         -5.81119        2.63374        2.00000
     ''',
     basis = '631g',
     verbose = 1, max_memory=10000)
@@ -55,11 +59,11 @@ def cellObject(x):
     mf.exxdiv = None
     emf = mf.kernel()
     
-    mc = mcscf.CASCI(mf, 2, 2)
+    mc = mcscf.CASCI(mf, 4, 4)
     ecasci = mc.kernel()[0]
 
-    las = LASSCF(mf, (2,), (2,))
-    mo0 = las.localize_init_guess((list(range(2)), ))
+    las = LASSCF(mf, (2,2), (2,2))
+    mo0 = las.localize_init_guess((list(range(2)),list(range(2, 4))))
     elasci = las.lasci(mo0)
 
     del cell, mc, mf, las
@@ -69,6 +73,6 @@ print(" Energy Comparision with cubic unit cell size ")
 print(f"{'LatticeVector(a)':<20} {'HF':<20} {'CASCI':<15} {'LASCI':<20}")
 print(f"{'Reference':<18} {memf:<18.9f} {mecasci:<18.9f} {melasci[1]:<18.9f}")
 
-for x in range(3,17, 2):
+for x in range(7,10,1):
     x, emf, ecasci, elasci = cellObject(x)
     print(f"{x:<18.1f} {emf:<18.9f} {ecasci:<18.9f} {elasci[1]:<18.9f}")

--- a/examples/pbc/lasci_gamma_point.py
+++ b/examples/pbc/lasci_gamma_point.py
@@ -1,0 +1,74 @@
+import numpy
+from pyscf import gto, scf
+from pyscf import mcscf
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
+from mrh.my_pyscf.tools.molden import from_lasscf
+
+'''
+Here I am doing first gamma point LASCI calculation
+For reference I did molecular calculation, periodic calculation
+with large unit cell (supercell) and at gamma point should be 
+equals to the molecular values
+Outcome of these calculations
+1. HF, CACI, and LASCI is converging to molecular value
+
+Molecular calculations are done without density fitting, but
+for periodic calculations FFTDF is by default on.
+Here i am using GDF
+Probably that's the reason of slow convergence!
+'''
+
+# Molecular Calculation
+mol = gto.M(atom = '''
+    H         -6.37665        2.20769        0.00000
+    H         -5.81119        2.63374       -0.00000
+    ''',
+    basis = '631g',
+    verbose = 4,max_memory=10000)
+
+mf = scf.RHF(mol)
+memf = mf.kernel()
+
+mc = mcscf.CASCI(mf, 2, 2)
+mecasci = mc.kernel()[0]
+
+las = LASSCF(mf, (2,), (2,))
+mo0 = las.localize_init_guess((list(range(2)),))
+melasci = las.lasci(mo0)
+
+del mol, mf, mc, las
+
+# Periodic Calculation
+from pyscf.pbc import gto, scf
+
+def cellObject(x):
+    cell = gto.M(a = numpy.eye(3)*x,
+    atom = '''
+    H         -6.37665        2.20769        0.00000
+    H         -5.81119        2.63374       -0.00000
+    ''',
+    basis = '631g',
+    verbose = 1, max_memory=10000)
+    cell.build()
+
+    mf = scf.RHF(cell).density_fit() # GDF
+    mf.exxdiv = None
+    emf = mf.kernel()
+    
+    mc = mcscf.CASCI(mf, 2, 2)
+    ecasci = mc.kernel()[0]
+
+    las = LASSCF(mf, (2,), (2,))
+    mo0 = las.localize_init_guess((list(range(2)), ))
+    elasci = las.lasci(mo0)
+
+    del cell, mc, mf, las
+    return x, emf, ecasci, elasci
+
+print(" Energy Comparision with cubic unit cell size ")
+print(f"{'LatticeVector(a)':<20} {'HF':<20} {'CASCI':<15} {'LASCI':<20}")
+print(f"{'Reference':<18} {memf:<18.9f} {mecasci:<18.9f} {melasci[1]:<18.9f}")
+
+for x in range(3,17, 2):
+    x, emf, ecasci, elasci = cellObject(x)
+    print(f"{x:<18.1f} {emf:<18.9f} {ecasci:<18.9f} {elasci[1]:<18.9f}")

--- a/tests/pbc/test_pbc_lasci.py
+++ b/tests/pbc/test_pbc_lasci.py
@@ -1,0 +1,35 @@
+import numpy
+import sys
+from pyscf import mcscf
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
+from pyscf.pbc import gto, scf
+import unittest
+
+class KnownValues(unittest.TestCase):
+    def test_h2(self):
+        cell = gto.M(a = numpy.eye(3)*5,
+        atom = '''
+            H         -6.37665        2.20769        3.00000
+            H         -5.81119        2.63374        3.00000
+        ''',
+        basis = 'sto3g',
+        verbose = 1, max_memory=10000)
+        cell.output = '/dev/null'
+        cell.build()
+
+        mf = scf.RHF(cell).density_fit() # GDF
+        mf.exxdiv = None
+        emf = mf.kernel()
+        
+        mc = mcscf.CASCI(mf, 2, 2)
+        ecasci = mc.kernel()[0]
+
+        las = LASSCF(mf, (2,), (2,))
+        mo0 = las.localize_init_guess((list(range(2)), ))
+        elasci = las.lasci(mo0)[1]
+
+        self.assertAlmostEqual (elasci, ecasci, 7)
+
+if __name__ == "__main__":
+    print("Full Tests for PBC-LASCI")
+    unittest.main()


### PR DESCRIPTION
Here I am doing first gamma point LASCI calculation
For reference I did molecular calculation, periodic calculation
with large unit cell (supercell) and at gamma point should be
equals to the molecular values

Outcome of these calculations
HF, CASCI and LASCI all are converging with increase in unit cell parameter.

 Energy Comparision with cubic unit cell size
LatticeVector(a)     HF                   CASCI           LASCI
Reference          -1.126455911       -1.131416794       -1.131416794
3.0                -0.782905616       -0.788326430       -0.788326430
5.0                -0.840719921       -0.845423952       -0.845423952
7.0                -0.916550355       -0.921332891       -0.921332891
9.0                -0.961783002       -0.966660755       -0.966660755
11.0               -0.991141516       -0.996058077       -0.996058077
13.0               -1.011676182       -1.016611303       -1.016611303
15.0               -1.026826439       -1.031771528       -1.031771528


Molecular calculations are done without density fitting, but
for periodic calculations DF is by default on. 
