### PR TITLE
Pip-Based Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 
 # Compilation
 lib/build/
+build/
 CMakeCache.txt
 CMakeFiles
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.egg-info
+*.info
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -41,13 +41,20 @@ pip install -e ./mrh
 
 OpenMP is required to build mrh. On macOS, CMake [cannot detect](https://stackoverflow.com/questions/46414660/macos-cmake-and-openmp) OpenMP when using the default compiler. The easiest work-around is to install GCC and OpenMP through [Homebrew](https://brew.sh/) and tell PySCF/pyscf-forge/mrh to [build with these compilers](https://pyscf.org/install.html#build-from-source-with-pip).
 
-See [brew.sh](https://brew.sh/) for Homebrew installation instructions and then install OpenMP by running `brew install libomp`.
+PySCF-Forge does not build correctly with the version of LibXC which is built or bundled with PySCF on macOS. It is easier to use a Homebrew-provided version.
+
+See [brew.sh](https://brew.sh/) for Homebrew installation instructions and then install OpenMP and LibXC by running `brew install libomp libxc`.
 
 Once installed, tell PySCF and related packages to use GCC 14 instead of macOS's Clang-based compiler by setting the `CMAKE_CONFIGURE_ARGS` environment variable.
 
 ```bash
 # Set the compiler
-export CMAKE_CONFIGURE_ARGS="-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14"
+export CMAKE_CONFIGURE_ARGS="-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DBUILD_LIBXC=OFF"
+
+# Set these to use the local libxc
+export LIBRARY_PATH="/opt/homebrew/lib"
+export C_INCLUDE_PATH="/opt/homebrew/include"
+export CPLUS_INCLUDE_PATH="/opt/homebrew/lib"
 
 # Enable a multi-threaded build (replace 12 with how many CPUs you have)
 export CMAKE_BUILD_ARGS="-- -j12"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone git@github.com:MatthewRHermes/mrh.git
 pip install -e ./mrh
 ```
 
-== Installing on macOS
+## Installing on macOS
 
 OpenMP is required to build mrh. On macOS, CMake [cannot detect](https://stackoverflow.com/questions/46414660/macos-cmake-and-openmp) OpenMP when using the default compiler. The easiest work-around is to install GCC and OpenMP through [Homebrew](https://brew.sh/) and tell PySCF/pyscf-forge/mrh to [build with these compilers](https://pyscf.org/install.html#build-from-source-with-pip).
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,59 @@
 # mrh
 GPL research code of Matthew R. Hermes
 
-### WARNING!
+## WARNING!
 The CSF-basis FCI solver and MC-PDFT and MC-DCFT modules (other than a few experimental features) have been *moved to [pyscf-forge](https://github.com/pyscf/pyscf-forge)* and are currently in the process of being removed from this project.
 
-### DEPENDENCIES:
+## Dependencies:
 - PySCF, including all header files in pyscf/lib
 - [pyscf-forge](https://github.com/pyscf/pyscf-forge)
 - see `pyscf_version.txt` and `pyscf-forge_version.txt` for last-tested versions or commits
 
-### INSTALLATION:
+### Installation 
+
+To use mrh, install the `master` branch through pip by running:
+
+```bash
+# Install PySCF and PySCF-Forge separatly (see note)
+
+# Install the compatible PySCF version
+pip install `curl -s https://raw.githubusercontent.com/GagliardiGroup/mrh/refs/heads/master/pyscf_version.txt | xargs`
+
+# Install the compatible PySCF-Forge version
+pip install `curl -s https://raw.githubusercontent.com/GagliardiGroup/mrh/refs/heads/master/pyscf-forge_version.txt | xargs`
+
+# Install MRH
+pip install git+https://github.com/MatthewRHermes/mrh.git
+```
+
+*NOTE:* Both mrh and pyscf-forge require PySCF as a build and runtime dependency. The pyscf-forge build script has a bug where the `pyscf/lib` directory is not corrected detected (it references a deleted temporary directory). This does not occur if PySCF is already installed.
+
+### Developer Installation
+
+Clone this repository and then tell pip to do an editable installation from the local directory.
+
+```bash
+git clone git@github.com:MatthewRHermes/mrh.git
+pip install -e ./mrh
+```
+
+== Installing on macOS
+
+OpenMP is required to build mrh. On macOS, CMake [cannot detect](https://stackoverflow.com/questions/46414660/macos-cmake-and-openmp) OpenMP when using the default compiler. The easiest work-around is to install GCC and OpenMP through [Homebrew](https://brew.sh/) and tell PySCF/pyscf-forge/mrh to [build with these compilers](https://pyscf.org/install.html#build-from-source-with-pip).
+
+See [brew.sh](https://brew.sh/) for Homebrew installation instructions and then install OpenMP by running `brew install libomp`.
+
+Once installed, tell PySCF and related packages to use GCC 14 instead of macOS's Clang-based compiler by setting the `CMAKE_CONFIGURE_ARGS` environment variable.
+
+```bash
+# Set the compiler
+export CMAKE_CONFIGURE_ARGS="-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14"
+
+# Enable a multi-threaded build (replace 12 with how many CPUs you have)
+export CMAKE_BUILD_ARGS="-- -j12"
+```
+
+### Legacy Install Method
 - cd /path/to/mrh/lib
 - mkdir build ; cd build
 - cmake ..
@@ -21,11 +65,11 @@ The CSF-basis FCI solver and MC-PDFT and MC-DCFT modules (other than a few exper
 - If you installed PySCF from source and the compilation still fails, try setting the path to the PySCF library directory manually:
 `cmake -DPYSCFLIB=/full/path/to/pyscf/lib ..`
 
-### Notes
+## Notes
 - The dev branch is continuously updated. The master branch is updated every time I pull PySCF and confirm that everything still works. If you have some issue and you think it may be related to PySCF version mismatch, try using the master branch and the precise PySCF commit indicated above.
 - If you are using Intel MKL as the BLAS library, you may need to enable the corresponding cmake option:
 `cmake -DBLA_VENDOR=Intel10_64lp_seq ..`
 
-### ACKNOWLEDGMENTS:
+## Acknoledgments
 - This work is supported by the U.S. Department of Energy, Office of Basic Energy Sciences, Division of Chemical Sciences, Geosciences and Biosciences through the Nanoporous Materials Genome Center under award DE-FG02-17ER16362.
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.19)
+
 # Modified from QC-DMET; see below
 #project (clib_qcdmet)
 #set (QC_DMET_VERSION      "0.1")
@@ -27,7 +29,7 @@ link_directories ($ENV{LD_LIBRARY_PATH})
 find_package (LAPACK REQUIRED)
 
 # OpenMP
-find_package (OpenMP)
+find_package (OpenMP REQUIRED)
 if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
@@ -58,20 +60,29 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O3")
 if (PYSCFLIB)
     message (STATUS "PYSCFLIB set by user: ${PYSCFLIB}")
 else ()
-    find_package (Python)
+    if (DEFINED ENV{VIRTUAL_ENV})
+        # There is a bug in FindPython where if the system version of
+        # Python is greater than the venv version of Python, CMake chooses
+        # the system version.
+        # (e.g. System: 3.13, VENV: 3.9 CMake choses 3.13)
+        # I will be open a bug.
+        set (Python_FIND_VIRTUALENV ONLY)
+    endif ()
+    find_package(Python)
+
     execute_process(
       COMMAND "${Python_EXECUTABLE}" -c "if True:
         import os
         from pyscf import lib
-        print (os.path.dirname (lib.__file__))"
+        print(os.path.dirname(lib.__file__))"
       OUTPUT_VARIABLE PYSCFLIB
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     message (STATUS "Trying to find PYSCFLIB: ${PYSCFLIB}")
 endif ()
 if (EXISTS ${PYSCFLIB})
-    message (STATUS "PYSCFLIB found!")
+    message(STATUS "PYSCFLIB found!")
 else ()
-    message (STATUS "PYSCFLIB not found!")
+    message(FATAL_ERROR "PYSCFLIB not found!")
 endif ()
 include_directories(${PYSCFLIB})
 include_directories(${PYSCFLIB}/deps/include)
@@ -80,7 +91,7 @@ link_directories(${PYSCFLIB})
 
 find_library(DFT_LIBRARY dft HINTS ${PYSCFLIB} )
 if(NOT DFT_LIBRARY)
-  message(FATAL_ERROR "PySCF dft library not found")
+  message(FATAL_ERROR  "PySCF dft library not found")
 endif()
 
 # Build the QC-DMET shared library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,8 @@ name = "mrh"
 authors = []
 description = ""
 dependencies = [
-    # Tested PySCF commit
-    "pyscf@git+https://github.com/pyscf/pyscf.git@befb2fed666ba5c4f074923c66a48ab81854dc65",
-    # Tested PySCF commit
-    "pyscf-forge@git+https://github.com/pyscf/pyscf-forge.git@4d0c803326b4250fbb28dd7ce0f3167af8cd2b93",
-    # Other dependencies
+    "pyscf",
+    "pyscf-forge",
     "numpy",
     "scipy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,27 @@
 [build-system]
-requires = ["setuptools", "wheel", "pyscf", "numpy"]
+# PySCF is a build requirement and a dependency
+requires = ["setuptools", "setuptools-scm", "pyscf"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
+name = "mrh"
+authors = []
+description = ""
+dependencies = [
+    # Tested PySCF commit
+    "pyscf@git+https://github.com/pyscf/pyscf.git@befb2fed666ba5c4f074923c66a48ab81854dc65",
+    # Tested PySCF commit
+    "pyscf-forge@git+https://github.com/pyscf/pyscf-forge.git@4d0c803326b4250fbb28dd7ce0f3167af8cd2b93",
+    # Other dependencies
+    "numpy",
+    "scipy"
+]
+
+# Handles the non-standard flat project layout
+# This may not build into a wheel
+[tool.setuptools.package-dir]
+"mrh" = "../mrh"
+
+# Enalbes versioning throught git commits/tags 
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.build_py import build_py
 from pathlib import Path
 
@@ -43,12 +43,14 @@ class CMakeBuildPy(build_py):
         Build artifict will be added to the `build` directory in the project root.
         Extension modules will be left in-place in the source directoris.
         """
+        src_dir = Path(src_dir)
+
         # Create build directory
-        build_dir = (self.build_base / src_dir / f"tmp.{self.plat_name}").absolute()
+        build_dir = (src_dir / "build" / f"tmp.{self.plat_name}").absolute()
         build_dir.mkdir(parents=True, exist_ok=True)
 
         # Pass CMake an absolute path
-        src_dir = Path(src_dir).absolute()
+        src_dir = src_dir.absolute()
 
         # Configure project
         self.announce(f'Configuring {src_dir}...', level=0)
@@ -69,7 +71,6 @@ class CMakeBuildPy(build_py):
 
     def run(self):
         self.plat_name = get_platform()
-        self.build_base = Path("build")
 
         configure_args = os.getenv('CMAKE_CONFIGURE_ARGS')
         self.configure_args = configure_args.split(' ') if configure_args else []

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# setup.py adapted from the PySCF. Reused under the Apache 2.0 License
+
+import os
+import sys
+from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py
+from pathlib import Path
+
+def get_platform():
+    from distutils.util import get_platform
+    platform = get_platform()
+    if sys.platform == 'darwin':
+        arch = os.getenv('CMAKE_OSX_ARCHITECTURES')
+        if arch:
+            osname = platform.rsplit('-', 1)[0]
+            if ';' in arch:
+                platform = f'{osname}-universal2'
+            else:
+                platform = f'{osname}-{arch}'
+        elif os.getenv('_PYTHON_HOST_PLATFORM'):
+            # the cibuildwheel environment
+            platform = os.getenv('_PYTHON_HOST_PLATFORM')
+            if platform.endswith('arm64'):
+                os.putenv('CMAKE_OSX_ARCHITECTURES', 'arm64')
+            elif platform.endswith('x86_64'):
+                os.putenv('CMAKE_OSX_ARCHITECTURES', 'x86_64')
+            else:
+                os.putenv('CMAKE_OSX_ARCHITECTURES', 'arm64;x86_64')
+    return platform
+
+class CMakeBuildPy(build_py):
+
+    # List of CMake projects
+    PROJECTS = [
+        "lib",
+        # "my_pyscf/lib"
+    ]
+
+    def CMake_build(self, src_dir):
+        """Build CMake project found in `src_dir`
+
+        Build artifict will be added to the `build` directory in the project root.
+        Extension modules will be left in-place in the source directoris.
+        """
+        # Create build directory
+        build_dir = (self.build_base / src_dir / f"tmp.{self.plat_name}").absolute()
+        build_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pass CMake an absolute path
+        src_dir = Path(src_dir).absolute()
+
+        # Configure project
+        self.announce(f'Configuring {src_dir}...', level=0)
+        cmd = ['cmake', f'-S{src_dir}', f'-B{build_dir}'] + self.configure_args
+        self.spawn(cmd)
+
+        # Build project
+        self.announce(f'Building {src_dir}...', level=3)
+        # By default do not use high level parallel compilation.
+        # OOM may be triggered when compiling certain functionals in libxc.
+        # Set the shell variable CMAKE_BUILD_PARALLEL_LEVEL=n to enable
+        # parallel compilation.
+        cmd = ['cmake', '--build', build_dir] + self.build_args
+        if self.dry_run:
+            self.announce(' '.join(cmd))
+        else:
+            self.spawn(cmd)
+
+    def run(self):
+        self.plat_name = get_platform()
+        self.build_base = Path("build")
+
+        configure_args = os.getenv('CMAKE_CONFIGURE_ARGS')
+        self.configure_args = configure_args.split(' ') if configure_args else []
+
+        build_args = os.getenv('CMAKE_BUILD_ARGS')
+        self.build_args = build_args.split(' ') if build_args else []
+
+        # Build each project
+        for project in self.PROJECTS:
+            self.CMake_build(project)
+
+        super().run()
+
+# build_py will produce plat_name = 'any'. Patch the bdist_wheel to change the
+# platform tag because the C extensions are platform dependent.
+# For setuptools<70
+from wheel.bdist_wheel import bdist_wheel
+initialize_options_1 = bdist_wheel.initialize_options
+def initialize_with_default_plat_name(self):
+    initialize_options_1(self)
+    self.plat_name = get_platform()
+    self.plat_name_supplied = True
+bdist_wheel.initialize_options = initialize_with_default_plat_name
+
+# For setuptools>=70
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel
+    initialize_options_2 = bdist_wheel.initialize_options
+    def initialize_with_default_plat_name(self):
+        initialize_options_2(self)
+        self.plat_name = get_platform()
+        self.plat_name_supplied = True
+    bdist_wheel.initialize_options = initialize_with_default_plat_name
+except ImportError:
+    pass
+
+
+setup(
+    #include *.so *.dat files. They are now placed in MANIFEST.in
+    #package_data={'': ['*.so', '*.dylib', '*.dll', '*.dat']},
+    include_package_data=True,  # include everything in source control
+    cmdclass={'build_py': CMakeBuildPy},
+)


### PR DESCRIPTION
These changes allow the mrh package to be installed with pip instead of manually updating `PYTHON_PATH` to include the source directory.

* Pip/`setup.py` handle building the `lib/` directory using code adapted from PYSCF
* Dependencies are specified in the `pyproject.toml` file
* The `README` has been updated to reflect these changes
* Installation instructions for macOS have been added
* `lib/CMakeLists.txt` has had minor bugfixes and missing OpenMP and PYSCF libraries are a fatal error..

This should make it easier to reference a specific release, such as with the new [LAS-QC project](https://github.com/GagliardiGroup/las-qc). Additionally, `pyproject.toml` uses [setuptools-scm](https://pypi.org/project/setuptools-scm/) which ties the package version number to Git tags and can be tied into GitHub's  releases feature.