### PR TITLE
Fix issues with cpu-only runs & mixing python versions

### DIFF
--- a/my_pyscf/gpu/libgpu.py
+++ b/my_pyscf/gpu/libgpu.py
@@ -3,8 +3,8 @@
 # Error messages like the following indicate trying to use the libgpu library, but not having installed/copied it to this directory.
 # AttributeError: module 'mrh.my_pyscf.gpu.libgpu' has no attribute 'libgpu_create_device'
 
-def libgpu_create_device():
+def create_device():
     raise RuntimeError("ERROR: You're attempting to use the libgpu library, but haven't correctly installed/copied it to mrh/my_pyscf/gpu/libgpu.so.")
 
-def libgpu_init():
+def init():
     raise RuntimeError("ERROR: You're attempting to use the libgpu library, but haven't correctly installed/copied it to mrh/my_pyscf/gpu/libgpu.so.")

--- a/my_pyscf/mcscf/las_ao2mo.py
+++ b/my_pyscf/mcscf/las_ao2mo.py
@@ -3,10 +3,6 @@ from scipy import linalg
 from pyscf import ao2mo, lib
 from mrh.my_pyscf.df.sparse_df import sparsedf_array
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 def get_h2eff_df (las, mo_coeff):
     # Store intermediate with one contracted ao index for faster calculation of exchange!
     log = lib.logger.new_logger (las, las.verbose)
@@ -15,8 +11,6 @@ def get_h2eff_df (las, mo_coeff):
     ncore, ncas = las.ncore, las.ncas
     nocc = ncore + ncas
     mo_cas = mo_coeff[:,ncore:nocc]
-    #if gpu: 
-    #    libgpu.push_mo_coeff(gpu,mo_cas.copy(),mo_cas.size)
     naux = las.with_df.get_naoaux ()
     log.debug2 ("LAS DF ERIs: %d MB used of %d MB total available", lib.current_memory ()[0], las.max_memory)
     mem_eris = 8*(nao+nmo)*ncas*ncas*ncas / 1e6
@@ -76,6 +70,7 @@ def get_h2eff_df (las, mo_coeff):
 
 #gpu accelerated version 
 def get_h2eff_gpu (las,mo_coeff):
+    from mrh.my_pyscf.gpu import libgpu
     log = lib.logger.new_logger (las, las.verbose)
     gpu=las.use_gpu
     nao, nmo = mo_coeff.shape
@@ -121,6 +116,7 @@ def get_h2eff_gpu (las,mo_coeff):
 
 #even faster gpu accelerated version currently, currently not working. 
 def get_h2eff_gpu_v2 (las,mo_coeff):
+    from mrh.my_pyscf.gpu import libgpu
     log = lib.logger.new_logger (las, las.verbose)
     gpu=las.use_gpu
     nao, nmo = mo_coeff.shape

--- a/my_pyscf/mcscf/las_ao2mo.py
+++ b/my_pyscf/mcscf/las_ao2mo.py
@@ -2,7 +2,10 @@ import numpy as np
 from scipy import linalg
 from pyscf import ao2mo, lib
 from mrh.my_pyscf.df.sparse_df import sparsedf_array
-from mrh.my_pyscf.gpu import libgpu
+
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
 
 def get_h2eff_df (las, mo_coeff):
     # Store intermediate with one contracted ao index for faster calculation of exchange!

--- a/my_pyscf/mcscf/lasci.py
+++ b/my_pyscf/mcscf/lasci.py
@@ -18,10 +18,6 @@ from scipy import linalg
 import numpy as np
 import copy
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 def LASCI (mf_or_mol, ncas_sub, nelecas_sub, **kwargs):
     if isinstance(mf_or_mol, gto.Mole):
         mf = scf.RHF(mf_or_mol)

--- a/my_pyscf/mcscf/lasci.py
+++ b/my_pyscf/mcscf/lasci.py
@@ -18,7 +18,9 @@ from scipy import linalg
 import numpy as np
 import copy
 
-from mrh.my_pyscf.gpu import libgpu
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
 
 def LASCI (mf_or_mol, ncas_sub, nelecas_sub, **kwargs):
     if isinstance(mf_or_mol, gto.Mole):

--- a/my_pyscf/mcscf/lasci_sync.py
+++ b/my_pyscf/mcscf/lasci_sync.py
@@ -5,7 +5,9 @@ from scipy.sparse import linalg as sparse_linalg
 from scipy import linalg 
 import numpy as np
 
-from mrh.my_pyscf.gpu import libgpu
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
 
 # This must be locked to CSF solver for the forseeable future, because I know of no other way to
 # handle spin-breaking potentials while retaining spin constraint

--- a/my_pyscf/mcscf/lasci_sync.py
+++ b/my_pyscf/mcscf/lasci_sync.py
@@ -5,10 +5,6 @@ from scipy.sparse import linalg as sparse_linalg
 from scipy import linalg 
 import numpy as np
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 # This must be locked to CSF solver for the forseeable future, because I know of no other way to
 # handle spin-breaking potentials while retaining spin constraint
 
@@ -1377,6 +1373,7 @@ class LASCI_HessianOperator (sparse_linalg.LinearOperator):
         return ci1
 
     def _update_h2eff_sub_gpu(self,gpu,mo1,umat,h2eff_sub):
+        from mrh.my_pyscf.gpu import libgpu
         ncore, ncas, nocc, nmo = self.ncore, self.ncas, self.nocc, self.nmo
         #ucas = umat[ncore:nocc, ncore:nocc]
         bmPu = None

--- a/my_pyscf/mcscf/lasscf_async/crunch.py
+++ b/my_pyscf/mcscf/lasscf_async/crunch.py
@@ -8,10 +8,6 @@ from pyscf.mcscf.addons import _state_average_mcscf_solver
 from mrh.my_pyscf.mcscf import _DFLASCI, lasci_sync, lasci
 import copy, json
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 class ImpurityMole (gto.Mole):
     def __init__(self, las, stdout=None, output=None):
         gto.Mole.__init__(self)
@@ -140,6 +136,7 @@ class ImpuritySCF (scf.hf.SCF):
         if hasattr (mf, 'use_gpu'): gpu = mf.mol.use_gpu
 
         if getattr (mf, 'with_df', None) is not None:
+            from mrh.my_pyscf.gpu import libgpu
             # TODO: impurity outcore cderi
             imporb_coeff=np.ascontiguousarray(imporb_coeff) 
             #VA - 4/29/25
@@ -613,6 +610,7 @@ class ImpuritySolver ():
                                       dm1s=None, casdm1rs=None, casdm2rs=None, weights=None):
         '''Update the Hamiltonian data contained within this impurity solver and all encapsulated
         impurity objects'''
+        from mrh.my_pyscf.gpu import libgpu
         las = self.mol._las
         gpu = las.use_gpu
         if h2eff_sub is None: h2eff_sub = las.ao2mo (mo_coeff)

--- a/my_pyscf/mcscf/lasscf_async/crunch.py
+++ b/my_pyscf/mcscf/lasscf_async/crunch.py
@@ -8,8 +8,10 @@ from pyscf.mcscf.addons import _state_average_mcscf_solver
 from mrh.my_pyscf.mcscf import _DFLASCI, lasci_sync, lasci
 import copy, json
 
-from mrh.my_pyscf.gpu import libgpu
-#DEBUG=True
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
+
 class ImpurityMole (gto.Mole):
     def __init__(self, las, stdout=None, output=None):
         gto.Mole.__init__(self)

--- a/my_pyscf/mcscf/lasscf_async/lasscf_async.py
+++ b/my_pyscf/mcscf/lasscf_async/lasscf_async.py
@@ -9,10 +9,6 @@ from mrh.my_pyscf.mcscf.lasscf_async import keyframe, combine
 from mrh.my_pyscf.mcscf.lasscf_async.split import get_impurity_space_constructor
 from mrh.my_pyscf.mcscf.lasscf_async.crunch import get_impurity_casscf
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 def kernel (las, mo_coeff=None, ci0=None, conv_tol_grad=1e-4,
             assert_no_dupes=False, verbose=lib.logger.NOTE, frags_orbs=None,
             **kwargs):

--- a/my_pyscf/mcscf/lasscf_async/lasscf_async.py
+++ b/my_pyscf/mcscf/lasscf_async/lasscf_async.py
@@ -9,7 +9,9 @@ from mrh.my_pyscf.mcscf.lasscf_async import keyframe, combine
 from mrh.my_pyscf.mcscf.lasscf_async.split import get_impurity_space_constructor
 from mrh.my_pyscf.mcscf.lasscf_async.crunch import get_impurity_casscf
 
-from mrh.my_pyscf.gpu import libgpu
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
 
 def kernel (las, mo_coeff=None, ci0=None, conv_tol_grad=1e-4,
             assert_no_dupes=False, verbose=lib.logger.NOTE, frags_orbs=None,

--- a/my_pyscf/mcscf/lasscf_sync_o0.py
+++ b/my_pyscf/mcscf/lasscf_sync_o0.py
@@ -10,7 +10,9 @@ from pyscf.lo import orth
 from pyscf.lib import tag_array, with_doc, logger
 from functools import partial
 
-from mrh.my_pyscf.gpu import libgpu
+import sys
+if 'gpu4mrh' in sys.modules:
+    from mrh.my_pyscf.gpu import libgpu
 
 # An implementation that carries out vLASSCF, but without utilizing Schmidt decompositions
 # or "fragment" subspaces, so that the orbital-optimization part scales no better than

--- a/my_pyscf/mcscf/lasscf_sync_o0.py
+++ b/my_pyscf/mcscf/lasscf_sync_o0.py
@@ -10,10 +10,6 @@ from pyscf.lo import orth
 from pyscf.lib import tag_array, with_doc, logger
 from functools import partial
 
-import sys
-if 'gpu4mrh' in sys.modules:
-    from mrh.my_pyscf.gpu import libgpu
-
 # An implementation that carries out vLASSCF, but without utilizing Schmidt decompositions
 # or "fragment" subspaces, so that the orbital-optimization part scales no better than
 # CASSCF. Eventually to be modified into a true all-PySCF implementation of vLASSCF
@@ -104,6 +100,7 @@ class LASSCF_HessianOperator (lasci_sync.LASCI_HessianOperator):
     def orbital_response (self, kappa, odm1s, ocm2, tdm1frs, tcm2, veff_prime):
         ''' Parent class does everything except va/ac degrees of freedom
         (c: closed; a: active; v: virtual; p: any) '''
+        from mrh.my_pyscf.gpu import libgpu
         ncore, nocc, nmo = self.ncore, self.nocc, self.nmo
         gorb = lasci_sync.LASCI_HessianOperator.orbital_response (self, kappa, odm1s,
             ocm2, tdm1frs, tcm2, veff_prime)


### PR DESCRIPTION
Fix some CPU-only issues related to libgpu to address #151 
* Correct names of functions in stub libgpu module
* Don't assume Mole object always has use_gpu attribute
* Only load libgpu if gpu4mrh has been loaded

This should resolve issues with differing python versions for cpu-only runs. If there is still an issue, then the hammer would be to copy `mrh/my_pyscf/gpu/libgpu.py` into `mrh/my_pyscf/gpu/stub` and update `PYTHON_PATH` appropriately to only import the stub completely removing `libgpu.so` from a searchable path.

GPU-accelerated runs with different python versions will likely run into trouble because of the pybind11 dependency. Python versions >=3.7 should be ok, but mixing with versions <3.7 will fail with undefined Py# symbols. If built with version <3.7 and try to use version >=3.7, then could see `interpreter version is incompatible` errors at runtime.  I think the solution here would be for the user to grab a copy of `mrh/gpu/src`, compile (but don't install), and update PYTHON_PATH appropriately to use their compiled libgpu.so. (This seems prone to error...)

```
cp -r /path_to_mrh/gpu/src ./
make ARCH=midway3
export PYTHON_PATH=${PWD}:$PYTHON_PATH
```