### PR TITLE
Addressing #182

### DIFF
--- a/tests/pbc/test_pbc_lasci.py
+++ b/tests/pbc/test_pbc_lasci.py
@@ -1,9 +1,9 @@
 import numpy
 import sys
-from pyscf import mcscf
-from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
-from pyscf.pbc import gto, scf
 import unittest
+from pyscf import mcscf
+from pyscf.pbc import gto, scf
+from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCFNoSymm as LASSCF
 
 class KnownValues(unittest.TestCase):
     def test_h2(self):


### PR DESCRIPTION
For non-core shell containing systems, the density_fit needed to handled with extra care. Currently I made this equivalent to how it is handled within the `mcscf.CASCI`