### PR TITLE
Adds missing log instantiation

### DIFF
--- a/my_pyscf/mcscf/lasscf_sync_o0.py
+++ b/my_pyscf/mcscf/lasscf_sync_o0.py
@@ -776,6 +776,7 @@ class LASSCF_HessianOperator (sparse_linalg.LinearOperator):
 
     def _init_eri_(self):
         _init_df_(self)
+        log = lib.logger.new_logger(self.las, self.las.verbose)
         if isinstance (self.las, _DFLASCI):
             self.cas_type_eris = mc_df._ERIS (self.las, self.mo_coeff, self.with_df)
         else:
@@ -789,7 +790,7 @@ class LASSCF_HessianOperator (sparse_linalg.LinearOperator):
         for p in range (self.nmo):
             paaa_test[p] = self.cas_type_eris.ppaa[p][ncore:nocc]
         if not np.allclose (paaa_test, self.eri_paaa):
-            logger.warn (self.las, 'possible (pa|aa) inconsistency; max err = %e',
+            log.warn(self.las, 'possible (pa|aa) inconsistency; max err = %e',
                          np.amax (np.abs (paaa_test-self.eri_paaa)))
 
     @property

--- a/my_pyscf/mcscf/lasscf_sync_o0.py
+++ b/my_pyscf/mcscf/lasscf_sync_o0.py
@@ -776,7 +776,6 @@ class LASSCF_HessianOperator (sparse_linalg.LinearOperator):
 
     def _init_eri_(self):
         _init_df_(self)
-        log = lib.logger.new_logger(self.las, self.las.verbose)
         if isinstance (self.las, _DFLASCI):
             self.cas_type_eris = mc_df._ERIS (self.las, self.mo_coeff, self.with_df)
         else:
@@ -790,7 +789,7 @@ class LASSCF_HessianOperator (sparse_linalg.LinearOperator):
         for p in range (self.nmo):
             paaa_test[p] = self.cas_type_eris.ppaa[p][ncore:nocc]
         if not np.allclose (paaa_test, self.eri_paaa):
-            log.warn(self.las, 'possible (pa|aa) inconsistency; max err = %e',
+            lib.logger.warn(self.las, 'possible (pa|aa) inconsistency; max err = %e',
                          np.amax (np.abs (paaa_test-self.eri_paaa)))
 
     @property


### PR DESCRIPTION
There was a missing logging statement in `LASSCF_HessianOperator` when it tries to warn a (pa|aa) issue.