### PR TITLE
Implementation of transition density matrices for the CPLX FCI

### DIFF
--- a/lib/pbclas/pbc_fci_rdms.c
+++ b/lib/pbclas/pbc_fci_rdms.c
@@ -138,6 +138,84 @@ void FCImake_rdm1b_cplx(double complex *rdm1,
 }
 
 
+/*
+ * Complex transition 1-RDMs.  Unlike FCImake_rdm1[ab]_cplx, these routines
+ * use both CI vectors, evaluate every orbital pair, and do not impose
+ * Hermiticity. Note: in python wrapper, we transpose it to get the respective
+ * rdm1[i, a] matrix (not conjugate transpose).  The matrix elements are defined as
+ *
+ *     rdm1[a,i] = <cibra|a^+_a a_i|ciket>.
+ */
+void FCItrans_rdm1a_cplx(double complex *rdm1,
+                         double complex *cibra,
+                         double complex *ciket,
+                         int norb, int na, int nb, int nlinka, int nlinkb,
+                         int *link_indexa, int *link_indexb)
+{
+        int i, a, j, k, str0, str1, sign;
+        double complex *pket, *pbra;
+        _LinkT *tab;
+        _LinkT *clink = malloc(sizeof(_LinkT) * (size_t)nlinka * (size_t)na);
+        FCIcompress_link(clink, link_indexa, norb, na, nlinka);
+
+        NPzset0(rdm1, norb*norb);
+        for (str0 = 0; str0 < na; str0++) {
+                tab = clink + str0 * nlinka;
+                pket = ciket + (size_t)str0 * (size_t)nb;
+                for (j = 0; j < nlinka; j++) {
+                        a    = EXTRACT_CRE (tab[j]);
+                        i    = EXTRACT_DES (tab[j]);
+                        str1 = EXTRACT_ADDR(tab[j]);
+                        sign = EXTRACT_SIGN(tab[j]);
+                        if (sign == 0) {
+                                break;
+                        }
+                        pbra = cibra + (size_t)str1 * (size_t)nb;
+                        for (k = 0; k < nb; k++) {
+                                rdm1[a*norb+i] += ((double)sign)
+                                                * conj(pbra[k]) * pket[k];
+                        }
+                }
+        }
+        free(clink);
+}
+
+
+void FCItrans_rdm1b_cplx(double complex *rdm1,
+                         double complex *cibra,
+                         double complex *ciket,
+                         int norb, int na, int nb, int nlinka, int nlinkb,
+                         int *link_indexa, int *link_indexb)
+{
+        int i, a, j, k, stra, str1, sign;
+        double complex *pket, *pbra;
+        _LinkT *tab;
+        _LinkT *clink = malloc(sizeof(_LinkT) * (size_t)nlinkb * (size_t)nb);
+        FCIcompress_link(clink, link_indexb, norb, nb, nlinkb);
+
+        NPzset0(rdm1, norb*norb);
+        for (stra = 0; stra < na; stra++) {
+                pbra = cibra + (size_t)stra * (size_t)nb;
+                pket = ciket + (size_t)stra * (size_t)nb;
+                for (k = 0; k < nb; k++) {
+                        tab = clink + k * nlinkb;
+                        for (j = 0; j < nlinkb; j++) {
+                                a    = EXTRACT_CRE (tab[j]);
+                                i    = EXTRACT_DES (tab[j]);
+                                str1 = EXTRACT_ADDR(tab[j]);
+                                sign = EXTRACT_SIGN(tab[j]);
+                                if (sign == 0) {
+                                        break;
+                                }
+                                rdm1[a*norb+i] += ((double)sign)
+                                                * conj(pbra[str1]) * pket[k];
+                        }
+                }
+        }
+        free(clink);
+}
+
+
 static void _transpose_jikl_cplx(double complex *dm2, int norb)
 {
         int nnorb = norb * norb;
@@ -471,6 +549,94 @@ void FCIrdm12kern_b_cplx(double complex *rdm1, double complex *rdm2,
                 }
         }
         free(buf);
+}
+
+
+/*
+ * Same-spin complex transition 1- and 2-RDM kernels.  buf0 is the
+ * one-body-excited ket and buf1 is the one-body-excited bra, so the 2-TDM
+ * contraction is buf0 * buf1^H rather than the ket-ket product used by the
+ * ordinary RDM kernels above.
+ */
+void FCItdm12kern_a_cplx(double complex *tdm1, double complex *tdm2,
+                         double complex *bra, double complex *ket,
+                         int bcount, int stra_id, int strb_id,
+                         int norb, int na, int nb, int nlinka, int nlinkb,
+                         _LinkT *clink_indexa, _LinkT *clink_indexb, int symm)
+{
+        const int INC1 = 1;
+        const char TRANS_N = 'N';
+        const char TRANS_C = 'C';
+        const double complex Z1 = 1.0;
+        const int nnorb = norb * norb;
+        double csum;
+        double complex *buf0 = calloc((size_t)nnorb * (size_t)bcount,
+                                      sizeof(double complex));
+        double complex *buf1 = calloc((size_t)nnorb * (size_t)bcount,
+                                      sizeof(double complex));
+        double complex *v = malloc(sizeof(double complex) * (size_t)bcount);
+
+        (void)symm;
+        csum = FCIrdm2_a_t1ci_cplx(bra, buf1, bcount, stra_id, strb_id,
+                                   norb, nb, nlinka, clink_indexa);
+        if (csum < CSUMTHR) { goto _normal_end_a; }
+        csum = FCIrdm2_a_t1ci_cplx(ket, buf0, bcount, stra_id, strb_id,
+                                   norb, nb, nlinka, clink_indexa);
+        if (csum < CSUMTHR) { goto _normal_end_a; }
+
+        for (int k = 0; k < bcount; k++) {
+                v[k] = conj(bra[(size_t)stra_id * (size_t)nb + strb_id + k]);
+        }
+        zgemv_(&TRANS_N, &nnorb, &bcount, &Z1, buf0, &nnorb,
+               v, &INC1, &Z1, tdm1, &INC1);
+        zgemm_(&TRANS_N, &TRANS_C, &nnorb, &nnorb, &bcount,
+               &Z1, buf0, &nnorb, buf1, &nnorb, &Z1, tdm2, &nnorb);
+
+_normal_end_a:
+        free(v);
+        free(buf1);
+        free(buf0);
+}
+
+
+void FCItdm12kern_b_cplx(double complex *tdm1, double complex *tdm2,
+                         double complex *bra, double complex *ket,
+                         int bcount, int stra_id, int strb_id,
+                         int norb, int na, int nb, int nlinka, int nlinkb,
+                         _LinkT *clink_indexa, _LinkT *clink_indexb, int symm)
+{
+        const int INC1 = 1;
+        const char TRANS_N = 'N';
+        const char TRANS_C = 'C';
+        const double complex Z1 = 1.0;
+        const int nnorb = norb * norb;
+        double csum;
+        double complex *buf0 = calloc((size_t)nnorb * (size_t)bcount,
+                                      sizeof(double complex));
+        double complex *buf1 = calloc((size_t)nnorb * (size_t)bcount,
+                                      sizeof(double complex));
+        double complex *v = malloc(sizeof(double complex) * (size_t)bcount);
+
+        (void)symm;
+        csum = FCIrdm2_b_t1ci_cplx(bra, buf1, bcount, stra_id, strb_id,
+                                   norb, nb, nlinkb, clink_indexb);
+        if (csum < CSUMTHR) { goto _normal_end_b; }
+        csum = FCIrdm2_b_t1ci_cplx(ket, buf0, bcount, stra_id, strb_id,
+                                   norb, nb, nlinkb, clink_indexb);
+        if (csum < CSUMTHR) { goto _normal_end_b; }
+
+        for (int k = 0; k < bcount; k++) {
+                v[k] = conj(bra[(size_t)stra_id * (size_t)nb + strb_id + k]);
+        }
+        zgemv_(&TRANS_N, &nnorb, &bcount, &Z1, buf0, &nnorb,
+               v, &INC1, &Z1, tdm1, &INC1);
+        zgemm_(&TRANS_N, &TRANS_C, &nnorb, &nnorb, &bcount,
+               &Z1, buf0, &nnorb, buf1, &nnorb, &Z1, tdm2, &nnorb);
+
+_normal_end_b:
+        free(v);
+        free(buf1);
+        free(buf0);
 }
 
 /*

--- a/my_pyscf/pbc/fci/direct_spin1_cplx.py
+++ b/my_pyscf/pbc/fci/direct_spin1_cplx.py
@@ -270,6 +270,48 @@ def make_hdiag(h1e, eri, norb, nelec, compress=False):
     hdiag_real = None
     return hdiag
 
+
+def trans_rdm1s(cibra, ciket, norb, nelec, link_index=None):
+    r'''Spin-separated complex transition 1-RDMs.'''
+    link_index = _unpack(norb, nelec, link_index)
+    dm1a = rdm_helper.trans_rdm1_spin1(
+        'FCItrans_rdm1a_cplx', cibra, ciket, norb, nelec, link_index)
+    dm1b = rdm_helper.trans_rdm1_spin1(
+        'FCItrans_rdm1b_cplx', cibra, ciket, norb, nelec, link_index)
+    return dm1a, dm1b
+
+
+def trans_rdm1(cibra, ciket, norb, nelec, link_index=None):
+    r'''Spin-summed complex transition 1-RDM.'''
+    dm1a, dm1b = trans_rdm1s(cibra, ciket, norb, nelec, link_index)
+    return dm1a + dm1b
+
+
+def trans_rdm12s(cibra, ciket, norb, nelec, link_index=None, reorder=True):
+    r'''Spin-separated complex transition 1- and 2-RDMs.'''
+    link_index = _unpack(norb, nelec, link_index)
+    dm1a, dm2aa = rdm_helper.trans_rdm12_spin1(
+        'FCItdm12kern_a_cplx', cibra, ciket, norb, nelec, link_index)
+    dm1b, dm2bb = rdm_helper.trans_rdm12_spin1(
+        'FCItdm12kern_b_cplx', cibra, ciket, norb, nelec, link_index)
+    _, dm2ab = rdm_helper.trans_rdm12_spin1(
+        'FCItdm12kern_ab_cplx', cibra, ciket, norb, nelec, link_index)
+    _, dm2ba = rdm_helper.trans_rdm12_spin1(
+        'FCItdm12kern_ab_cplx', ciket, cibra, norb, nelec, link_index)
+    dm2ba = dm2ba.transpose(3, 2, 1, 0).conj()
+    if reorder:
+        dm1a, dm2aa = rdm_helper.reorder_tdm(dm1a, dm2aa, inplace=True)
+        dm1b, dm2bb = rdm_helper.reorder_tdm(dm1b, dm2bb, inplace=True)
+    return (dm1a, dm1b), (dm2aa, dm2ab, dm2ba, dm2bb)
+
+
+def trans_rdm12(cibra, ciket, norb, nelec, link_index=None, reorder=True):
+    r'''Spin-summed complex transition 1- and 2-RDM.'''
+    (dm1a, dm1b), (dm2aa, dm2ab, dm2ba, dm2bb) = trans_rdm12s(
+        cibra, ciket, norb, nelec, link_index=link_index, reorder=reorder)
+    return dm1a + dm1b, dm2aa + dm2ab + dm2ba + dm2bb
+
+
 def make_rdm1s(fcivec, norb, nelec, link_index=None):
     make_rdm1s.__doc__ = direct_spin1.make_rdm1s.__doc__ + '''
     Compute the spin-separated 1-RDMs for a complex FCI vector using the backend C function.
@@ -348,6 +390,33 @@ def make_rdm12_py(fcivec, norb, nelec, link_index=None, reorder=True):
     rdm1 = dm1a + dm1b
     rdm2 = dm2aa + dm2bb + dm2ab + dm2ab.transpose(2, 3, 0, 1)
     return rdm1.conj().T, rdm2
+
+
+def make_tdm1s_py(cibra, ciket, norb, nelec, link_index=None):
+    r'''Python implementation of spin-separated complex transition 1-RDMs.'''
+    link_index = _unpack(norb, nelec, link_index)
+    return rdm_helper.make_tdm1s_py(
+        cibra, ciket, norb, nelec, link_index=link_index)
+
+
+def make_tdm12s_py(cibra, ciket, norb, nelec, link_index=None,
+                   reorder=True):
+    r'''Python implementation of spin-separated complex transition RDMs.'''
+    link_index = _unpack(norb, nelec, link_index)
+    return rdm_helper.make_tdm12s_py(
+        cibra, ciket, norb, nelec, link_index=link_index, reorder=reorder)
+
+
+def trans_rdm1s_py(cibra, ciket, norb, nelec, link_index=None):
+    r'''Alias matching the PySCF transition-RDM naming convention.'''
+    return make_tdm1s_py(cibra, ciket, norb, nelec, link_index=link_index)
+
+
+def trans_rdm12s_py(cibra, ciket, norb, nelec, link_index=None,
+                    reorder=True):
+    r'''Alias matching the PySCF transition-RDM naming convention.'''
+    return make_tdm12s_py(
+        cibra, ciket, norb, nelec, link_index=link_index, reorder=reorder)
 
 def _make_diag_precond(hdiag, level_shift=1e-3):
     '''
@@ -629,6 +698,22 @@ class FCISolver(direct_spin1.FCISolver):
     def make_rdm12(self, fcivec, norb, nelec, link_index=None, reorder=True):
         return make_rdm12(fcivec, norb, nelec, link_index, reorder)
 
+    def trans_rdm1s(self, cibra, ciket, norb, nelec, link_index=None):
+        return trans_rdm1s(cibra, ciket, norb, nelec, link_index)
+
+    def trans_rdm1(self, cibra, ciket, norb, nelec, link_index=None):
+        return trans_rdm1(cibra, ciket, norb, nelec, link_index)
+
+    def trans_rdm12s(self, cibra, ciket, norb, nelec, link_index=None,
+                     reorder=True):
+        return trans_rdm12s(
+            cibra, ciket, norb, nelec, link_index, reorder)
+
+    def trans_rdm12(self, cibra, ciket, norb, nelec, link_index=None,
+                    reorder=True):
+        return trans_rdm12(
+            cibra, ciket, norb, nelec, link_index, reorder)
+
     def get_init_guess(self, norb, nelec, nroots, hdiag):
         return get_init_guess_cplx(norb, nelec, nroots, hdiag)
     
@@ -643,6 +728,22 @@ class FCISolver(direct_spin1.FCISolver):
     
     def make_rdm12_py(self, fcivec, norb, nelec, link_index=None, reorder=True):
         return make_rdm12_py(fcivec, norb, nelec, link_index, reorder)
+
+    def make_tdm1s_py(self, cibra, ciket, norb, nelec, link_index=None):
+        return make_tdm1s_py(cibra, ciket, norb, nelec, link_index)
+
+    def make_tdm12s_py(self, cibra, ciket, norb, nelec, link_index=None,
+                       reorder=True):
+        return make_tdm12s_py(
+            cibra, ciket, norb, nelec, link_index, reorder)
+
+    def trans_rdm1s_py(self, cibra, ciket, norb, nelec, link_index=None):
+        return trans_rdm1s_py(cibra, ciket, norb, nelec, link_index)
+
+    def trans_rdm12s_py(self, cibra, ciket, norb, nelec, link_index=None,
+                        reorder=True):
+        return trans_rdm12s_py(
+            cibra, ciket, norb, nelec, link_index, reorder)
     
     def contract_ss(self, fcivec, norb, nelec):
         nelec = _unpack_nelec(nelec, self.spin)

--- a/my_pyscf/pbc/fci/rdm_helper.py
+++ b/my_pyscf/pbc/fci/rdm_helper.py
@@ -17,30 +17,44 @@ libpbcrdm = load_library('libpbc_fci_rdms')
 # 1. Spin-summed excitation operator implementation in backend C code, which would be useful
 #    for computing optimizing the code.
 
-def reorder_rdm(dm1, dm2, inplace=True):
+def _reorder_rdm_tdm(dm1, dm2, inplace=True, tdm=False):
     norb = dm1.shape[0]
     if not inplace:
         dm2 = dm2.copy()
     for r in range(norb):
-        dm2[:, r, r, :] -= dm1.conj().T
+        if tdm:
+            dm2[:, r, r, :] -= dm1.T
+        else:
+            dm2[:, r, r, :] -= dm1.conj().T
     return dm1, dm2
 
-def make_rdm1_spin1(fname, cibra, ciket, norb, nelec, link_index=None):
+
+def reorder_rdm(dm1, dm2, inplace=True):
+    return _reorder_rdm_tdm(dm1, dm2, inplace=inplace, tdm=False)
+
+
+def reorder_tdm(tdm1, tdm2, inplace=True):
+    return _reorder_rdm_tdm(tdm1, tdm2, inplace=inplace, tdm=True)
+
+
+def _make_rdm1_tdm1_spin1(fname, cibra, ciket, norb, nelec,
+                           link_index=None, tdm=False):
+    r'''
+    Call a complex spin-resolved 1-RDM or transition-1-RDM kernel.
     '''
-    Wrapper function for backend C function, to compute the spin-separated 1-RDMs.
-    '''
-    assert (cibra is not None and ciket is not None)
-    cibra = np.asarray(cibra, order='C')
-    ciket = np.asarray(ciket, order='C')
-    dtype = ciket.dtype
+
+    assert cibra is not None and ciket is not None
+    cibra = np.asarray(cibra, dtype=np.complex128, order='C')
+    ciket = np.asarray(ciket, dtype=np.complex128, order='C')
     link_indexa, link_indexb = _unpack(norb, nelec, link_index)
-    na,nlinka = link_indexa.shape[:2]
-    nb,nlinkb = link_indexb.shape[:2]
-    assert (cibra.size == na*nb), '{} {} {}'.format (cibra.size, na, nb)
-    assert (ciket.size == na*nb), '{} {} {}'.format (ciket.size, na, nb)
-    rdm1 = np.empty((norb,norb), dtype=dtype, order='C')
+    na, nlinka = link_indexa.shape[:2]
+    nb, nlinkb = link_indexb.shape[:2]
+    assert cibra.size == na * nb, '{} {} {}'.format(cibra.size, na, nb)
+    assert ciket.size == na * nb, '{} {} {}'.format(ciket.size, na, nb)
+
+    dm1 = np.empty((norb, norb), dtype=np.complex128, order='C')
     fn = getattr(libpbcrdm, fname)
-    fn(rdm1.ctypes.data_as(ctypes.c_void_p),
+    fn(dm1.ctypes.data_as(ctypes.c_void_p),
        cibra.ctypes.data_as(ctypes.c_void_p),
        ciket.ctypes.data_as(ctypes.c_void_p),
        ctypes.c_int(norb),
@@ -48,61 +62,62 @@ def make_rdm1_spin1(fname, cibra, ciket, norb, nelec, link_index=None):
        ctypes.c_int(nlinka), ctypes.c_int(nlinkb),
        link_indexa.ctypes.data_as(ctypes.c_void_p),
        link_indexb.ctypes.data_as(ctypes.c_void_p))
-    return rdm1.conj().T
+    return dm1.T if tdm else dm1.conj().T
 
-def make_rdm12_spin1(fname, cibra, ciket, norb, nelec, link_index=None, symm=0):
-    '''
-    Wrapper function for backend C function, to compute the spin-separated 1-RDMs and 2-RDMs.
-    args:
-        fname: str, name of the C function to call
-            either 'FCIrdm12kern_a_cplx' or 'FCIrdm12kern_b_cplx' or 'FCIrdm12kern_ab_cplx' 
-             on the spin block of the 2-RDM to be computed
-        cibra: np.ndarray of shape (na*nb, )
-            complex FCI bra vector
-        ciket: np.ndarray of shape (na*nb, )
-            complex FCI ket vector
-        norb: int
-            number of orbitals (ncas * nkpts)
-        nelec: tuple of ints
-            number of alpha and beta electrons (nelecasa, nelecb)
-        link_index: tuple of np.ndarray
-            link indices for alpha and beta strings
-        symm: int
-            symmetry sector to compute the RDMs for, default is 0 (no symmetry)
-    returns:
-        rdm1: np.ndarray of shape (norb, norb)
-            spin-separated 1-RDM (either alpha or beta depending on fname)
-        rdm2: np.ndarray of shape (norb, norb, norb, norb)
-            spin-separated 2-RDM (either alpha-alpha, beta-beta or alpha-beta depending on fname)
-    '''
-    assert (cibra is not None and ciket is not None)
-    cibra = np.asarray(cibra, order='C')
-    ciket = np.asarray(ciket, order='C')
+
+def make_rdm1_spin1(fname, cibra, ciket, norb, nelec, link_index=None):
+    r'''Wrapper for a complex spin-resolved ordinary 1-RDM kernel.'''
+    return _make_rdm1_tdm1_spin1(fname, cibra, ciket, norb, nelec, 
+                                 link_index, tdm=False)
+
+def trans_rdm1_spin1(fname, cibra, ciket, norb, nelec, link_index=None):
+    r'''Wrapper for a complex spin-resolved transition 1-RDM kernel.'''
+    return _make_rdm1_tdm1_spin1(fname, cibra, ciket, norb, nelec, 
+                                 link_index, tdm=True)
+
+def _make_rdm12_tdm12_spin1(fname, cibra, ciket, norb, nelec,
+                             link_index=None, symm=0, tdm=False):
+    r'''Call a complex spin-resolved 1-/2-RDM or transition-RDM kernel.'''
+    assert cibra is not None and ciket is not None
+    cibra = np.asarray(cibra, dtype=np.complex128, order='C')
+    ciket = np.asarray(ciket, dtype=np.complex128, order='C')
     link_indexa, link_indexb = _unpack(norb, nelec, link_index)
-    na,nlinka = link_indexa.shape[:2]
-    nb,nlinkb = link_indexb.shape[:2]
+    na, nlinka = link_indexa.shape[:2]
+    nb, nlinkb = link_indexb.shape[:2]
+    assert cibra.size == na * nb
+    assert ciket.size == na * nb
 
-    assert (cibra.size == na*nb)
-    assert (ciket.size == na*nb)
-
-    rdm1 = np.empty((norb,norb), dtype=np.complex128, order='C')
-    rdm2 = np.empty((norb,norb,norb,norb), dtype=np.complex128, order='C')
-
-    # In case I don't set the one of the OMP_THREADS or MKL_NUM_THREADS env variables to one
-    # there is nested parallelization which slows down the code.
+    dm1 = np.empty((norb, norb), dtype=np.complex128, order='C')
+    dm2 = np.empty((norb, norb, norb, norb),
+                   dtype=np.complex128, order='C')
     with lib.with_omp_threads(1):
-        libpbcrdm.FCIrdm12_drv_cplx(getattr(libpbcrdm, fname),
-                            rdm1.ctypes.data_as(ctypes.c_void_p),
-                            rdm2.ctypes.data_as(ctypes.c_void_p),
-                            cibra.ctypes.data_as(ctypes.c_void_p),
-                            ciket.ctypes.data_as(ctypes.c_void_p),
-                            ctypes.c_int(norb),
-                            ctypes.c_int(na), ctypes.c_int(nb),
-                            ctypes.c_int(nlinka), ctypes.c_int(nlinkb),
-                            link_indexa.ctypes.data_as(ctypes.c_void_p),
-                            link_indexb.ctypes.data_as(ctypes.c_void_p),
-                            ctypes.c_int(symm))
-    return rdm1.conj().T, rdm2
+        libpbcrdm.FCIrdm12_drv_cplx(
+            getattr(libpbcrdm, fname),
+            dm1.ctypes.data_as(ctypes.c_void_p),
+            dm2.ctypes.data_as(ctypes.c_void_p),
+            cibra.ctypes.data_as(ctypes.c_void_p),
+            ciket.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(norb),
+            ctypes.c_int(na), ctypes.c_int(nb),
+            ctypes.c_int(nlinka), ctypes.c_int(nlinkb),
+            link_indexa.ctypes.data_as(ctypes.c_void_p),
+            link_indexb.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(symm))
+    return (dm1.T if tdm else dm1.conj().T), dm2
+
+
+def make_rdm12_spin1(fname, cibra, ciket, norb, nelec, link_index=None,
+                     symm=0):
+    r'''Wrapper for a complex spin-resolved ordinary 1-/2-RDM kernel.'''
+    return _make_rdm12_tdm12_spin1(fname, cibra, ciket, norb, nelec, 
+                                   link_index, symm, tdm=False)
+
+
+def trans_rdm12_spin1(fname, cibra, ciket, norb, nelec, link_index=None,
+                      symm=0):
+    r'''Wrapper for a complex spin-resolved transition 1-/2-RDM kernel.'''
+    return _make_rdm12_tdm12_spin1(fname, cibra, ciket, norb, nelec, 
+                                   link_index, symm, tdm=True)
 
 def make_rdm1s_py(fcivec, norb, nelec, link_index=None):
     '''
@@ -143,6 +158,7 @@ def make_rdm1s_py(fcivec, norb, nelec, link_index=None):
             rdm1b[p, i] += sign * np.vdot(civec[:, b0], civec[:, b1])
 
     return (rdm1a, rdm1b)
+
 
 def make_rdm12s_py(fcivec, norb, nelec, link_index=None, reorder=True):
     '''
@@ -226,3 +242,108 @@ def make_rdm12s_py(fcivec, norb, nelec, link_index=None, reorder=True):
     dm2bb = dm2bb.transpose(0, 2, 1, 3).conj()
     return (dm1a, dm1b), (dm2aa, dm2ab, dm2bb)
 
+
+def make_tdm1s_py(cibra, ciket, norb, nelec, link_index=None):
+    r'''Python implementation of spin-separated transition 1-RDMs.
+
+    ``tdm1[p,q] = <cibra|q^\dagger p|ciket>``.  Neither CI vector is
+    normalized or modified.
+    '''
+    neleca, nelecb = _unpack_nelec(nelec)
+    link_indexa, link_indexb = _unpack(norb, nelec, link_index)
+    na = cistring.num_strings(norb, neleca)
+    nb = cistring.num_strings(norb, nelecb)
+    cibra = np.asarray(cibra).reshape(na, nb)
+    ciket = np.asarray(ciket).reshape(na, nb)
+    dtype = np.result_type(cibra.dtype, ciket.dtype)
+
+    tdm1a = np.zeros((norb, norb), dtype=dtype)
+    tdm1b = np.zeros((norb, norb), dtype=dtype)
+    for a0, tab in enumerate(link_indexa):
+        for a, i, a1, sign in tab:
+            if sign == 0:
+                break
+            tdm1a[i, a] += sign * np.vdot(cibra[a1, :], ciket[a0, :])
+    for b0, tab in enumerate(link_indexb):
+        for a, i, b1, sign in tab:
+            if sign == 0:
+                break
+            tdm1b[i, a] += sign * np.vdot(cibra[:, b1], ciket[:, b0])
+    return tdm1a, tdm1b
+
+
+def _make_tdm12_same_spin_py(cibra, ciket, norb, link_index,
+                              other_size, reorder):
+    dtype = np.result_type(cibra.dtype, ciket.dtype)
+    tdm1 = np.zeros((norb, norb), dtype=dtype)
+    tdm2 = np.zeros((norb, norb, norb, norb), dtype=dtype)
+    for str0, tab in enumerate(link_index):
+        t1bra = np.zeros((norb, norb, other_size), dtype=dtype)
+        t1ket = np.zeros_like(t1bra)
+        for a, i, str1, sign in tab:
+            if sign == 0:
+                break
+            t1bra[i, a, :] += sign * cibra[str1, :]
+            t1ket[i, a, :] += sign * ciket[str1, :]
+        tdm1 += np.einsum(
+            'B,iaB->ai', cibra[str0, :].conj(), t1ket, optimize=True)
+        tdm2 += np.einsum(
+            'iaB,jbB->aijb', t1bra.conj(), t1ket, optimize=True)
+    if reorder:
+        tdm1, tdm2 = reorder_tdm(tdm1, tdm2, inplace=True)
+    return tdm1, tdm2
+
+
+def _make_tdm2ab_py(cibra, ciket, norb, link_indexa, link_indexb):
+    nb = ciket.shape[1]
+    dtype = np.result_type(cibra.dtype, ciket.dtype)
+    tdm2ab = np.zeros((norb, norb, norb, norb), dtype=dtype)
+    beta_tabs = []
+    for tab in link_indexb:
+        ops = []
+        for a, i, str1, sign in tab:
+            if sign == 0:
+                break
+            ops.append((a, i, str1, sign))
+        beta_tabs.append(ops)
+
+    for stra, tab in enumerate(link_indexa):
+        t1keta = np.zeros((norb, norb, nb), dtype=dtype)
+        for a, i, str1, sign in tab:
+            if sign == 0:
+                break
+            t1keta[i, a, :] += sign * ciket[str1, :]
+        bra_row = cibra[stra, :].conj()
+        for strb, ops in enumerate(beta_tabs):
+            for a, i, str1, sign in ops:
+                tdm2ab[:, :, i, a] += (
+                    bra_row[strb] * sign * t1keta[:, :, str1])
+    return tdm2ab
+
+
+def make_tdm12s_py(cibra, ciket, norb, nelec, link_index=None,
+                    reorder=True):
+    r'''Python implementation of spin-separated transition 1- and 2-RDMs.
+
+    Returns ``(tdm1a, tdm1b), (tdm2aa, tdm2ab, tdm2ba, tdm2bb)`` with
+    ``tdm2[p,q,r,s] = <cibra|p^\dagger r^\dagger s q|ciket>`` when
+    ``reorder`` is true.
+    '''
+    neleca, nelecb = _unpack_nelec(nelec)
+    link_indexa, link_indexb = _unpack(norb, nelec, link_index)
+    na = cistring.num_strings(norb, neleca)
+    nb = cistring.num_strings(norb, nelecb)
+    cibra = np.asarray(cibra).reshape(na, nb)
+    ciket = np.asarray(ciket).reshape(na, nb)
+
+    tdm1a, tdm2aa = _make_tdm12_same_spin_py(
+        cibra, ciket, norb, link_indexa, nb, reorder)
+    tdm1b, tdm2bb = _make_tdm12_same_spin_py(
+        cibra.T, ciket.T, norb, link_indexb, na, reorder)
+    tdm2ab = _make_tdm2ab_py(
+        cibra, ciket, norb, link_indexa, link_indexb)
+    tdm2ba = _make_tdm2ab_py(
+        ciket, cibra, norb, link_indexa, link_indexb)
+    tdm2ba = tdm2ba.transpose(3, 2, 1, 0).conj()
+
+    return (tdm1a, tdm1b), (tdm2aa, tdm2ab, tdm2ba, tdm2bb)

--- a/tests/pbc/test_pbc_rdm.py
+++ b/tests/pbc/test_pbc_rdm.py
@@ -86,6 +86,7 @@ def _compare_two_RDM(dmA, dmB):
     np.testing.assert_allclose(dmA.imag, dmB.imag, atol=1e-10, rtol=1e-10)
     np.testing.assert_allclose(dmA, dmB, atol=1e-10, rtol=1e-10)
 
+
 class KnownValues(unittest.TestCase):
 
     # Unit-Test-1: In the limit of the zero imaginary part of CI coeff, the
@@ -211,3 +212,4 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     # print("Full Tests for RDM construction")
     unittest.main()
+

--- a/tests/pbc/test_pbc_tdm.py
+++ b/tests/pbc/test_pbc_tdm.py
@@ -1,0 +1,282 @@
+#!/bin/bash
+import unittest
+import numpy as np
+
+from pyscf.pbc import gto as pgto
+from pyscf.fci import direct_spin1
+from pyscf.fci import cistring
+
+from mrh.my_pyscf.pbc.fci import direct_spin1_cplx
+
+# Author: Bhavnesh Jangid
+
+'''
+There are four transition-density functions
+    1. trans_rdm1s (spin-separated TDM1)
+    2. trans_rdm1 (spin-summed TDM1)
+    3. trans_rdm12s (spin-separated TDM1 and TDM2)
+    4. trans_rdm12 (spin-summed TDM1 and TDM2)
+
+The complex C implementation is compared against the Python
+implementation and a complex reference constructed from real PySCF calls.
+'''
+
+def dummy_cell():
+    cell = pgto.Cell()
+    cell.atom = '''
+    Ne 0.000000000000 0.000000000000 0.000000000000
+    Ne 0.000000000000 0.000000000000 3.500000000000
+    '''
+    cell.a = np.diag([10.0, 10.0, 10.0])
+    cell.basis = '6-31G'
+    cell.unit = 'Angstrom'
+    cell.verbose = 0
+    cell.build()
+    return cell
+
+
+def _compare_two_TDM(dmA, dmB):
+    assert dmA.shape == dmB.shape
+    np.testing.assert_allclose(dmA.real, dmB.real,
+                               atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(dmA.imag, dmB.imag,
+                               atol=1e-10, rtol=1e-10)
+    np.testing.assert_allclose(dmA, dmB, atol=1e-10, rtol=1e-10)
+
+
+def _complex_tdm_reference(real_tdm_fn, cibra, ciket, *args, **kwargs):
+    r'''Build a complex TDM from four real PySCF calls.'''
+    tdm_rr = real_tdm_fn(cibra.real, ciket.real, *args, **kwargs)
+    tdm_ii = real_tdm_fn(cibra.imag, ciket.imag, *args, **kwargs)
+    tdm_ri = real_tdm_fn(cibra.real, ciket.imag, *args, **kwargs)
+    tdm_ir = real_tdm_fn(cibra.imag, ciket.real, *args, **kwargs)
+    def combine(tdm_rr, tdm_ii, tdm_ri, tdm_ir):
+        if isinstance(tdm_rr, (tuple, list)):
+            return tuple(combine(*blocks) 
+                         for blocks in zip(tdm_rr, tdm_ii, tdm_ri, tdm_ir))
+        return tdm_rr + tdm_ii + 1j * (tdm_ri - tdm_ir)
+    return combine(tdm_rr, tdm_ii, tdm_ri, tdm_ir)
+
+
+class KnownValues(unittest.TestCase):
+
+    def test_complex_tdm12_and_tdm12s(self):
+        ncas = 5
+        nelecas = (2, 2)
+        na = cistring.num_strings(ncas, nelecas[0])
+        nb = cistring.num_strings(ncas, nelecas[1])
+        rng = np.random.default_rng(12)
+        cibra = rng.random((na, nb)) + 1j * rng.random((na, nb))
+        ciket = rng.random((na, nb)) + 1j * rng.random((na, nb))
+        cibra /= np.linalg.norm(cibra)
+        ciket /= np.linalg.norm(ciket)
+
+        cisolver = direct_spin1_cplx.FCISolver(dummy_cell())
+        for reorder in (False, True):
+            tdm12s_ref = _complex_tdm_reference(direct_spin1.trans_rdm12s, 
+                                                cibra, ciket, ncas, nelecas, 
+                                                reorder=reorder)
+            (tdm1a_ref, tdm1b_ref), (
+                tdm2aa_ref, tdm2ab_ref, tdm2ba_ref, tdm2bb_ref) = tdm12s_ref
+
+            (tdm1a, tdm1b), (
+                tdm2aa, tdm2ab, tdm2ba, tdm2bb) = cisolver.trans_rdm12s(
+                    cibra, ciket, ncas, nelecas, reorder=reorder)
+            
+            (tdm1a_py, tdm1b_py), (
+                tdm2aa_py, tdm2ab_py, tdm2ba_py,
+                tdm2bb_py) = cisolver.trans_rdm12s_py(
+                    cibra, ciket, ncas, nelecas, reorder=reorder)
+
+            # Compare the complex C implementation, the Python implementation, 
+            # and the reference from real PySCF calls.
+            for dmA, dmB in [
+                    (tdm1a, tdm1a_ref), (tdm1b, tdm1b_ref),
+                    (tdm2aa, tdm2aa_ref), (tdm2ab, tdm2ab_ref),
+                    (tdm2ba, tdm2ba_ref), (tdm2bb, tdm2bb_ref),
+                    (tdm1a_py, tdm1a), (tdm1b_py, tdm1b),
+                    (tdm2aa_py, tdm2aa), (tdm2ab_py, tdm2ab),
+                    (tdm2ba_py, tdm2ba), (tdm2bb_py, tdm2bb)]:
+                _compare_two_TDM(dmA, dmB)
+
+            tdm1, tdm2 = cisolver.trans_rdm12(
+                cibra, ciket, ncas, nelecas, reorder=reorder)
+            _compare_two_TDM(tdm1, tdm1a_ref + tdm1b_ref)
+            _compare_two_TDM(
+                tdm2, tdm2aa_ref + tdm2ab_ref + tdm2ba_ref + tdm2bb_ref)
+
+        tdm1a_from_trans_rdm1s, tdm1b_from_trans_rdm1s = \
+            cisolver.trans_rdm1s(cibra, ciket, ncas, nelecas)
+        tdm1a_from_trans_rdm1s_py, tdm1b_from_trans_rdm1s_py = \
+            cisolver.trans_rdm1s_py(cibra, ciket, ncas, nelecas)
+        tdm1_from_trans_rdm1 = cisolver.trans_rdm1(
+            cibra, ciket, ncas, nelecas)
+        _compare_two_TDM(tdm1a_from_trans_rdm1s, tdm1a)
+        _compare_two_TDM(tdm1b_from_trans_rdm1s, tdm1b)
+        _compare_two_TDM(tdm1a_from_trans_rdm1s_py, tdm1a)
+        _compare_two_TDM(tdm1b_from_trans_rdm1s_py, tdm1b)
+        _compare_two_TDM(tdm1_from_trans_rdm1, tdm1a + tdm1b)
+
+        link_index = (
+            cistring.gen_linkstr_index(range(ncas), nelecas[0]),
+            cistring.gen_linkstr_index(range(ncas), nelecas[1]))
+        (tdm1a_with_links, tdm1b_with_links), (
+            tdm2aa_with_links, tdm2ab_with_links,
+            tdm2ba_with_links, tdm2bb_with_links) = cisolver.trans_rdm12s(
+                cibra, ciket, ncas, nelecas, link_index=link_index)
+        for dmA, dmB in [
+                (tdm1a_with_links, tdm1a),
+                (tdm1b_with_links, tdm1b),
+                (tdm2aa_with_links, tdm2aa),
+                (tdm2ab_with_links, tdm2ab),
+                (tdm2ba_with_links, tdm2ba),
+                (tdm2bb_with_links, tdm2bb)]:
+            _compare_two_TDM(dmA, dmB)
+
+        overlap = np.vdot(cibra, ciket)
+        np.testing.assert_allclose(
+            np.trace(tdm1a), nelecas[0] * overlap, atol=1e-10)
+        np.testing.assert_allclose(
+            np.trace(tdm1b), nelecas[1] * overlap, atol=1e-10)
+        pair_counts = (nelecas[0] * (nelecas[0] - 1),
+                       nelecas[0] * nelecas[1],
+                       nelecas[1] * nelecas[0],
+                       nelecas[1] * (nelecas[1] - 1))
+        for dm2, count in zip(
+                (tdm2aa, tdm2ab, tdm2ba, tdm2bb), pair_counts):
+            np.testing.assert_allclose(
+                np.einsum('ppqq->', dm2), count * overlap, atol=1e-10)
+
+    def test_tdm_in_limit_to_RDM(self):
+        ncas = 5
+        nelecas = (2, 2)
+        na = cistring.num_strings(ncas, nelecas[0])
+        nb = cistring.num_strings(ncas, nelecas[1])
+        rng = np.random.default_rng(21)
+        fcivec = rng.random((na, nb)) + 1j * rng.random((na, nb))
+        fcivec /= np.linalg.norm(fcivec)
+
+        cisolver = direct_spin1_cplx.FCISolver(dummy_cell())
+
+        rdm1a_from_make_rdm1s, rdm1b_from_make_rdm1s = \
+            cisolver.make_rdm1s(fcivec, ncas, nelecas)
+        rdm1_from_make_rdm1 = cisolver.make_rdm1(fcivec, ncas, nelecas)
+        (rdm1a, rdm1b), (rdm2aa, rdm2ab, rdm2bb) = \
+            cisolver.make_rdm12s(fcivec, ncas, nelecas)
+        rdm1, rdm2 = cisolver.make_rdm12(fcivec, ncas, nelecas)
+
+        tdm1a_from_trans_rdm1s, tdm1b_from_trans_rdm1s = \
+            cisolver.trans_rdm1s(fcivec, fcivec, ncas, nelecas)
+        tdm1_from_trans_rdm1 = cisolver.trans_rdm1(
+            fcivec, fcivec, ncas, nelecas)
+        (tdm1a, tdm1b), (tdm2aa, tdm2ab, tdm2ba, tdm2bb) = \
+            cisolver.trans_rdm12s(fcivec, fcivec, ncas, nelecas)
+        tdm1, tdm2 = cisolver.trans_rdm12(
+            fcivec, fcivec, ncas, nelecas)
+
+        for dmA, dmB in [
+                (tdm1a_from_trans_rdm1s, rdm1a_from_make_rdm1s),
+                (tdm1b_from_trans_rdm1s, rdm1b_from_make_rdm1s),
+                (tdm1_from_trans_rdm1, rdm1_from_make_rdm1),
+                (tdm1a, rdm1a), (tdm1b, rdm1b),
+                (tdm2aa, rdm2aa), (tdm2ab, rdm2ab),
+                (tdm2ba, rdm2ab.transpose(2, 3, 0, 1)),
+                (tdm2bb, rdm2bb), (tdm1, rdm1), (tdm2, rdm2)]:
+            _compare_two_TDM(dmA, dmB)
+
+        (rdm1a_py, rdm1b_py), (
+            rdm2aa_py, rdm2ab_py, rdm2bb_py) = cisolver.make_rdm12s_py(
+                fcivec.copy(), ncas, nelecas)
+        (tdm1a_py, tdm1b_py), (
+            tdm2aa_py, tdm2ab_py, tdm2ba_py,
+            tdm2bb_py) = cisolver.trans_rdm12s_py(
+                fcivec, fcivec, ncas, nelecas)
+        rdm1a_from_make_rdm1s_py, rdm1b_from_make_rdm1s_py = \
+            cisolver.make_rdm1s_py(fcivec, ncas, nelecas)
+        tdm1a_from_trans_rdm1s_py, tdm1b_from_trans_rdm1s_py = \
+            cisolver.trans_rdm1s_py(fcivec, fcivec, ncas, nelecas)
+
+        for dmA, dmB in [
+                (tdm1a_from_trans_rdm1s_py, rdm1a_from_make_rdm1s_py),
+                (tdm1b_from_trans_rdm1s_py, rdm1b_from_make_rdm1s_py),
+                (tdm1a_py, rdm1a_py), (tdm1b_py, rdm1b_py),
+                (tdm2aa_py, rdm2aa_py), (tdm2ab_py, rdm2ab_py),
+                (tdm2ba_py, rdm2ab_py.transpose(2, 3, 0, 1)),
+                (tdm2bb_py, rdm2bb_py)]:
+            _compare_two_TDM(dmA, dmB)
+
+    def test_tdm_bra_ket_adjoint(self):
+        ncas = 4
+        nelecas = (2, 1)
+        na = cistring.num_strings(ncas, nelecas[0])
+        nb = cistring.num_strings(ncas, nelecas[1])
+        rng = np.random.default_rng(7)
+        cibra = rng.random((na, nb)) + 1j * rng.random((na, nb))
+        ciket = rng.random((na, nb)) + 1j * rng.random((na, nb))
+
+        cisolver = direct_spin1_cplx.FCISolver(dummy_cell())
+        (tdm1a_bk, tdm1b_bk), (
+            tdm2aa_bk, tdm2ab_bk, tdm2ba_bk,
+            tdm2bb_bk) = cisolver.trans_rdm12s(
+                cibra, ciket, ncas, nelecas)
+        (tdm1a_kb, tdm1b_kb), (
+            tdm2aa_kb, tdm2ab_kb, tdm2ba_kb,
+            tdm2bb_kb) = cisolver.trans_rdm12s(
+                ciket, cibra, ncas, nelecas)
+
+        for dmA, dmB in [
+                (tdm1a_bk, tdm1a_kb.conj().T),
+                (tdm1b_bk, tdm1b_kb.conj().T),
+                (tdm2aa_bk, tdm2aa_kb.transpose(1, 0, 3, 2).conj()),
+                (tdm2ab_bk, tdm2ab_kb.transpose(1, 0, 3, 2).conj()),
+                (tdm2ba_bk, tdm2ba_kb.transpose(1, 0, 3, 2).conj()),
+                (tdm2bb_bk, tdm2bb_kb.transpose(1, 0, 3, 2).conj())]:
+            _compare_two_TDM(dmA, dmB)
+
+        tdm1_bk, tdm2_bk = cisolver.trans_rdm12(
+            cibra, ciket, ncas, nelecas)
+        tdm1_kb, tdm2_kb = cisolver.trans_rdm12(
+            ciket, cibra, ncas, nelecas)
+        _compare_two_TDM(tdm1_bk, tdm1_kb.conj().T)
+        _compare_two_TDM(
+            tdm2_bk, tdm2_kb.transpose(1, 0, 3, 2).conj())
+
+    def test_tdm_electron_sectors(self):
+        ncas = 4
+        nelecaslst = [(0, 0), (4, 0), (0, 4), (4, 4), (2, 1), (1, 3)]
+        rng = np.random.default_rng(91)
+        cisolver = direct_spin1_cplx.FCISolver(dummy_cell())
+
+        for nelecas in nelecaslst:
+            with self.subTest(nelecas=nelecas):
+                na = cistring.num_strings(ncas, nelecas[0])
+                nb = cistring.num_strings(ncas, nelecas[1])
+                cibra = rng.random((na, nb)) + 1j * rng.random((na, nb))
+                ciket = rng.random((na, nb)) + 1j * rng.random((na, nb))
+
+                (tdm1a, tdm1b), (
+                    tdm2aa, tdm2ab, tdm2ba,
+                    tdm2bb) = cisolver.trans_rdm12s(
+                        cibra, ciket, ncas, nelecas)
+                
+                (tdm1a_py, tdm1b_py), (
+                    tdm2aa_py, tdm2ab_py, tdm2ba_py,
+                    tdm2bb_py) = cisolver.trans_rdm12s_py(
+                        cibra, ciket, ncas, nelecas)
+
+                for dmA, dmB in [
+                        (tdm1a, tdm1a_py), (tdm1b, tdm1b_py),
+                        (tdm2aa, tdm2aa_py), (tdm2ab, tdm2ab_py),
+                        (tdm2ba, tdm2ba_py), (tdm2bb, tdm2bb_py)]:
+                    _compare_two_TDM(dmA, dmB)
+
+                overlap = np.vdot(cibra, ciket)
+                np.testing.assert_allclose(
+                    np.trace(tdm1a), nelecas[0] * overlap, atol=1e-10)
+                np.testing.assert_allclose(
+                    np.trace(tdm1b), nelecas[1] * overlap, atol=1e-10)
+
+
+if __name__ == '__main__':
+    unittest.main()
+    


### PR DESCRIPTION
The current `RDM` implementation of the CPLX FCI vector doesn't have the transition density matrix implementation. These are required in the constructing the `hop` for the `kLAS`. In this PR, I have added:

- [x] The spin-separated and spin-summed 1-TDM and 2-TDM. Note the spin-summed TDM are made from spin-separated. Added the low-level and python implementation.
- [x] Added the unit-test to test the implementation.