### PR TITLE
Update the location of SOC in doc str

### DIFF
--- a/examples/dmetandpdmet/10_dmet_soc.py
+++ b/examples/dmetandpdmet/10_dmet_soc.py
@@ -5,14 +5,12 @@ from mrh.my_pyscf.dmet import runDMET
 from mrh.my_pyscf.gto import get_ano_rcc_basis
 
 '''
-SOC interactions with-in DMET Framework at QDPT level using BP or DK Hamiltonian:
+SOC interactions with-in DMET Framework at QDPT level using BP or DKH Hamiltonian:
 One can use this with following methods CAS, MC-PDFT, NEVPT2, and L-PDFT.
 '''
 
 '''
-Currently, the SOC is hosted on my local fork of pyscf-forge:
-https://github.com/JangidBhavnesh/pyscf-forge/tree/qdptsoclpdft
-In future, I will try to push this to main pyscf-forge repo.
+SISO is hosted on the PySCF-Forge repository.
 '''
 
 np.set_printoptions(precision=4)


### PR DESCRIPTION
Previously the SOC was hosted in my local fork of pyscf-forge. Now, I have opened a PR https://github.com/pyscf/pyscf-forge/pull/206 . On merging of this, I need to update the doc str.