### PR TITLE
Moving the Gamma point PDFT from molecular folder to pbc folder

### DIFF
--- a/examples/pbc/pdft_gamma_point.py
+++ b/examples/pbc/pdft_gamma_point.py
@@ -1,11 +1,17 @@
 
 '''
 Here, I am doing the gamma-point CASSCF followed by PDFT.
-Note: 
-    1. mf.exxdiv=None should be used. Post-SCF method require this.
-    2. I am using GDF. In case of default DF which is FFTDF, the grids 
-    for the periodic DFT will change. Which I haven't tested yet.
-    3. Also, the MCPDFT (tPBE) == PBE with SD active space and same mo_coeff.
+
+Note:
+    1. mf.exxdiv=None should be used. Post-SCF methods require this.
+    2. This example uses GDF. The default FFTDF path has not been tested for
+       periodic MC-PDFT.
+    3. Periodic MC-PDFT must be initialized from a periodic HF object. Do not
+       pass an RKS/UKS object or convert one to RHF: the required density-fitting
+       ERIs may not be available or consistent. Build and run the HF/GDF object
+       directly so that its integrals are generated correctly.
+    4. For a single-determinant active space and fixed HF orbitals, tPBE equals
+       PBE evaluated non-self-consistently on the same HF density.
 '''
 
 
@@ -27,7 +33,7 @@ Cartesian
 import numpy as np
 from pyscf.pbc import gto, scf, dft
 from pyscf import mcscf
-from mrh.my_pyscf import mcpdft
+from mrh.my_pyscf.pbc import mcpdft
 
 # Periodic Calculation for CH=CH uni, using CASCI vs RHF
 def getcell():
@@ -49,16 +55,23 @@ def getcell():
     cell.build()
     return cell
 
-def periodicDFT():
+def periodicPDFT():
     cell = getcell()
-    mf = scf.RKS(cell).density_fit()
-    mf.verbose=4
-    mf.exxdiv=None
-    mf.xc='pbe'
-    eperpbe = mf.kernel()
+    mf = scf.RHF(cell).density_fit()
+    mf.exxdiv = None
+    mf.kernel()
+
+    # Evaluate PBE on the HF density without optimizing DFT orbitals.
+    ks = dft.RKS(cell).density_fit()
+    ks.verbose = 4
+    ks.exxdiv = None
+    ks.xc = 'pbe'
+    ks.max_cycle = 0
+    eperpbe = ks.kernel(mf.make_rdm1())
+
     mc = mcpdft.CASCI(mf, 'tPBE', 1,2)
     epdftper = mc.kernel(mf.mo_coeff)[0]
-    print("Periodic Cal (PBE vs tPBE): ", np.allclose(eperpbe,epdftper, 1e-7))
+    print("Periodic Cal (PBE@HF vs tPBE): ", np.allclose(eperpbe,epdftper, 1e-7))
 
 def periodicHF():
     cell = getcell()
@@ -71,4 +84,4 @@ def periodicHF():
 
 if __name__ == "__main__":
     periodicHF()
-    periodicDFT() 
+    periodicPDFT()

--- a/my_pyscf/mcpdft/__init__.py
+++ b/my_pyscf/mcpdft/__init__.py
@@ -25,9 +25,6 @@ def _MCPDFT(mc_class, mc_or_mf_or_mol, ot, ncas, nelecas, ncore=None, frozen=Non
         mc0 = None
         mf_or_mol = mc_or_mf_or_mol
 
-    # Redefine the otfnal class for periodic systems
-    ot = periodicpdft(mc_or_mf_or_mol, ot)
-
     if isinstance(mf_or_mol, gto.Mole) and mf_or_mol.symmetry:
         logger.warn(mf_or_mol,
                     'Initializing MC-SCF with a symmetry-adapted Mole object may not work!')
@@ -47,11 +44,32 @@ def _MCPDFT(mc_class, mc_or_mf_or_mol, ot, ncas, nelecas, ncore=None, frozen=Non
 
 def CASSCFPDFT(mc_or_mf_or_mol, ot, ncas, nelecas, ncore=None, frozen=None,
                **kwargs):
+    if _is_periodic(mc_or_mf_or_mol):
+        from mrh.my_pyscf.pbc import mcpdft as pbc_mcpdft
+        return pbc_mcpdft.CASSCFPDFT(
+            mc_or_mf_or_mol,
+            ot,
+            ncas,
+            nelecas,
+            ncore=ncore,
+            frozen=frozen,
+            **kwargs,
+        )
     return _MCPDFT(mcscf.CASSCF, mc_or_mf_or_mol, ot, ncas, nelecas, ncore=ncore, frozen=frozen,
                    **kwargs)
 
 
 def CASCIPDFT(mc_or_mf_or_mol, ot, ncas, nelecas, ncore=None, **kwargs):
+    if _is_periodic(mc_or_mf_or_mol):
+        from mrh.my_pyscf.pbc import mcpdft as pbc_mcpdft
+        return pbc_mcpdft.CASCIPDFT(
+            mc_or_mf_or_mol,
+            ot,
+            ncas,
+            nelecas,
+            ncore=ncore,
+            **kwargs,
+        )
     return _MCPDFT(mcscf.CASCI, mc_or_mf_or_mol, ot, ncas, nelecas, ncore=ncore,
                    **kwargs)
 
@@ -70,9 +88,6 @@ def _laspdftEnergy(mc_class, mc_or_mf_or_mol, ot, ncas_sub, nelecas_sub, DoLASSI
     else:
         mc0 = None
         mf_or_mol = mc_or_mf_or_mol
-
-    # Redefine the otfnal class for periodic systems
-    ot = periodicpdft(mc_or_mf_or_mol, ot)
 
     if isinstance(mf_or_mol, gto.Mole) and mf_or_mol.symmetry:
         logger.warn(mf_or_mol,
@@ -132,6 +147,18 @@ def LASSCFPDFT(mc_or_mf_or_mol, ot, ncas_sub=None, nelecas_sub=None, ncore=None,
                **kwargs):
     if ncas_sub is None: ncas_sub = getattr(mc_or_mf_or_mol, 'ncas_sub', None)
     if nelecas_sub is None: nelecas_sub = getattr(mc_or_mf_or_mol, 'nelecas_sub', None)
+    if _is_periodic(mc_or_mf_or_mol):
+        from mrh.my_pyscf.pbc import mcpdft as pbc_mcpdft
+        return pbc_mcpdft.LASSCFPDFT(
+            mc_or_mf_or_mol,
+            ot,
+            ncas_sub=ncas_sub,
+            nelecas_sub=nelecas_sub,
+            ncore=ncore,
+            spin_sub=spin_sub,
+            frozen=frozen,
+            **kwargs,
+        )
     from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF
     return _laspdftEnergy(LASSCF, mc_or_mf_or_mol, ot, ncas_sub, nelecas_sub, ncore=ncore,
                           spin_sub=spin_sub, frozen=frozen, **kwargs)
@@ -161,61 +188,21 @@ def CIMCPDFT_SCF(*args, **kwargs):
     return fn(mcscf.CASSCF, *args, **kwargs)
 
 def _getmole(mc_or_mf_mol):
-    '''
-    A function to get the mol object from the mc_or_mf_mol object
-    '''
+    """Compatibility alias for the periodic molecule/cell resolver."""
+    from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import _get_mol_or_cell
+    return _get_mol_or_cell(mc_or_mf_mol)
+
+
+def _is_periodic(mc_or_mf_mol):
     from pyscf.pbc import gto as pbcgto
-    if isinstance(mc_or_mf_mol, (mc1step.CASSCF, casci.CASCI)):
-        return mc_or_mf_mol._scf.mol
-    elif isinstance(mc_or_mf_mol, gto.Mole) or isinstance(mc_or_mf_mol, pbcgto.cell.Cell):
-        return mc_or_mf_mol
-    else:
-        return mc_or_mf_mol.mol
-    
+    return isinstance(_getmole(mc_or_mf_mol), pbcgto.cell.Cell)
 
 def periodicpdft(mc_or_mf_mol, ot):
-    """
-    A wrapper function to check whether the mol is cell object or not.
-    if yes, then the otfnal class will be modified.
-    
-    Note: Remember to write the sanity check for the kpts.
-    
-    Also, this is not the best way to handle the situation but it works for now.In future,
-    I will put this in mrh.pbc folder.
-
-    Args:
-        mc: mcscf object
-    """
-    mol = _getmole(mc_or_mf_mol)
-    assert isinstance(ot, str), "The ot should be a string"
-    from pyscf.pbc import gto
-    if isinstance(mol, gto.cell.Cell):
-        from mrh.my_pyscf.mcpdft.otfnalperiodic import _get_transfnal
-        sanity_check_for_kpts(mc_or_mf_mol)
-        fnal = _get_transfnal(mc_or_mf_mol, ot)
-        return fnal
-    else:
-        return ot
+    """Compatibility wrapper for the periodic gamma-point dispatcher."""
+    from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import periodicpdft as fn
+    return fn(mc_or_mf_mol, ot)
 
 def sanity_check_for_kpts(mc_or_mf_mol):
-    '''
-    A function to check total number of kpts if it is greater than 1
-    raise an error.
-    '''
-    if hasattr(mc_or_mf_mol, '_scf'):
-        nkpts = len(mc_or_mf_mol._scf.kpts)
-    
-    elif hasattr(mc_or_mf_mol, '_las'):
-        nkpts = len(mc_or_mf_mol._las._scf.kpts)
-
-    elif hasattr(mc_or_mf_mol, 'kpts'):
-        nkpts = len(mc_or_mf_mol.kpts)
-
-    else:
-        raise NotImplementedError ("The input object does not have kpts attribute")
-    
-    if nkpts > 1:
-        raise ValueError ("Only supercell calculations can be performend with MCPDFT")
-    
-    
-    
+    """Compatibility wrapper for the periodic gamma-point check."""
+    from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import sanity_check_for_kpts as fn
+    return fn(mc_or_mf_mol)

--- a/my_pyscf/mcpdft/laspdft.py
+++ b/my_pyscf/mcpdft/laspdft.py
@@ -55,11 +55,12 @@ class _LASPDFT(_PDFT):
     def multi_state(self, method='Lin'):
         raise NotImplementedError(f"MS-PDFT not avaialble for the LAS wave functions.")
 
-def get_mcpdft_child_class(mc, ot, DoLASSI=False, states=None, **kwargs):
+def get_mcpdft_child_class(mc, ot, DoLASSI=False, states=None,
+                           _pdft_class=_LASPDFT, **kwargs):
     mc_doc = (mc.__class__.__doc__ or 'No docstring for MC-SCF parent method')
 
-    class PDFT(_LASPDFT, mc.__class__):
-        __doc__ = mc_doc + '\n\n' + _LASPDFT.__doc__
+    class PDFT(_pdft_class, mc.__class__):
+        __doc__ = mc_doc + '\n\n' + _pdft_class.__doc__
         _mc_class = mc.__class__
         setattr(_mc_class, 'DoLASSI', None)
         setattr(_mc_class, 'states', None)
@@ -70,12 +71,12 @@ def get_mcpdft_child_class(mc, ot, DoLASSI=False, states=None, **kwargs):
             if self._in_mcscf_env:
                 return mc.__class__.get_h2eff(self, mo_coeff=mo_coeff)
             else:
-                return _LASPDFT.get_h2eff(self, mo_coeff=mo_coeff)
+                return _pdft_class.get_h2eff(self, mo_coeff=mo_coeff)
         
         # Have to pass this due to dump_chk, which won't work for LAS.
         def compute_pdft_energy_(self, mo_coeff=None, ci=None, ot=None, otxc=None,
                                  grids_level=None, grids_attr=None, dump_chk=False, **kwargs):
-            return _LASPDFT.compute_pdft_energy_(self, mo_coeff=mo_coeff, ci=ci, ot=ot, otxc=otxc,
+            return _pdft_class.compute_pdft_energy_(self, mo_coeff=mo_coeff, ci=ci, ot=ot, otxc=otxc,
                     grids_level=grids_level, grids_attr=grids_attr, dump_chk=False, **kwargs)
 
         if DoLASSI:

--- a/my_pyscf/mcpdft/otfnalperiodic.py
+++ b/my_pyscf/mcpdft/otfnalperiodic.py
@@ -1,139 +1,36 @@
-import numpy as np
-from pyscf.lib import logger, param
-from pyscf.mcpdft import _dms
-from pyscf.mcpdft.otpd import get_ontop_pair_density
-from pyscf.mcpdft.otfnal import otfnal
-from mrh.my_pyscf.mcpdft import _getmole
-from pyscf.mcpdft.otfnal import get_transfnal
-from pyscf.mcpdft.otfnal import transfnal, ftransfnal
-from pyscf import __config__
+"""Backward-compatible imports for periodic on-top functionals.
 
-def redefine_fnal(original_class, new_parent):
-    from pyscf import lib
-    class transfnal (original_class.__class__, new_parent):
-        pass
-    new_fnal = lib.view (original_class, transfnal)
-    return new_fnal
+Periodic MC-PDFT is implemented in :mod:`mrh.my_pyscf.pbc.mcpdft`.  This
+module retains the historical import paths used by downstream callers.
+"""
 
-redefine_transfnal = redefine_fnal
-redefine_ftransfnal = redefine_fnal
-
-class otfnalperiodic(otfnal):
-    '''
-    Child class to define the otfnal class for periodic systems (Only for 1x1x1 kpts)
-    '''
-
-    def energy_ot (ot, casdm1s, casdm2, mo_coeff, ncore, max_memory=param.MAX_MEMORY, hermi=1):
-        '''
-        See the docstring of pyscf/mcpdft/otfnal.energy_ot for more information.
-        '''
-
-        E_ot = 0.0
-        ni = ot._numint
-        xctype =  ot.xctype
-
-        if xctype=='HF': 
-            return E_ot
-        
-        dens_deriv = ot.dens_deriv
-
-        nao = mo_coeff.shape[0]
-        ncas = casdm2.shape[0]
-        cascm2 = _dms.dm2_cumulant (casdm2, casdm1s)
-        
-        dm1s = _dms.casdm1s_to_dm1s (ot, casdm1s, mo_coeff=mo_coeff, ncore=ncore,
-                                    ncas=ncas)
-        mo_cas = mo_coeff[:,ncore:][:,:ncas]
-        t0 = (logger.process_clock (), logger.perf_counter ())
-        make_rho = tuple (ni._gen_rho_evaluator (ot.mol, dm1s[i,:,:], hermi) for
-            i in range(2))
-        
-        for ao_k1, ao_k2, mask, weight, _ \
-            in ni.block_loop(ot.mol, ot.grids, nao, deriv=dens_deriv, kpt=None, max_memory=max_memory):
-            '''
-            ao_k1 and ao_k2 are the block of AO integrals for the given k-point. They
-            are the same for supercell(1x1x1) calculations.
-            '''
-
-            rho = np.asarray ([m[0] (0, ao_k1, mask, xctype) for m in make_rho])
-            t0 = logger.timer (ot, 'untransformed density', *t0)
-            Pi = get_ontop_pair_density (ot, rho, ao_k1, cascm2, mo_cas,
-                dens_deriv, mask)
-            t0 = logger.timer (ot, 'on-top pair density calculation', *t0)
-            if rho.ndim == 2:
-                rho = np.expand_dims (rho, 1)
-                Pi = np.expand_dims (Pi, 0)
-            E_ot += ot.eval_ot (rho, Pi, dderiv=0, weights=weight)[0].dot (weight)
-            t0 = logger.timer (ot, 'on-top energy calculation', *t0)
-
-        return E_ot
-    
-    energy_ot.__doc__ = otfnal.energy_ot.__doc__
-
-    def reset(self, mol=None):
-        '''
-        Discard cached grid data and optionally update the cell object.
-        I am not changing the input parameter so that it is compatible with the current
-        MCPDFT code.
-        '''
-        if mol is not None:
-            self.mol = mol
-        # A hack to reset the grids for the new cell object.
-        self.grids.reset (mol) 
+from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import (
+    _get_ks_obj,
+    _get_mol_or_cell,
+    get_pbc_otfnal_gamma,
+    otfnalperiodic_gamma,
+    periodicpdft,
+    redefine_fnal,
+    redefine_ftransfnal,
+    redefine_transfnal,
+    sanity_check_for_kpts,
+)
 
 
-def sanity_check_for_df(mc_or_mf_mol):
-    '''
-    A function to check whether the density fitting is GDF, MDF or FFTDF
-    and initialize the appropriate KS object for the periodic MCPDFT calculations.
-    '''
-    from pyscf.pbc import dft
-    mol = _getmole (mc_or_mf_mol)
-    if hasattr(mc_or_mf_mol, 'with_df'):
-        dfclass = mc_or_mf_mol.with_df.__class__.__name__
-    
-    elif hasattr(mc_or_mf_mol, '_las'):
-        dfclass = mc_or_mf_mol._las.with_df.__class__.__name__
+otfnalperiodic = otfnalperiodic_gamma
+_get_transfnal = get_pbc_otfnal_gamma
+sanity_check_for_df = _get_ks_obj
 
-    else:
-        raise ValueError ("The input object does not have with_df attribute. \
-                          Start with Mean-field object")
-    if dfclass == 'GDF':
-        ks = dft.RKS(mol).density_fit()
-    elif dfclass == 'MDF':
-        ks = dft.RKS(mol).mix_density_fit()
-    else:
-        raise NotImplementedError ("PBD-MCPDFT is yet not implemented for FFTDF")
-    return ks
-
-def _get_transfnal (mc_or_mf_mol, otxc):
-    '''
-    This is wrapper function to get the appropriate fnal class for the given cell object
-    '''
-    mol = _getmole (mc_or_mf_mol)
-    fnal_class = get_transfnal (mol, otxc)
-    fnal_class_type = fnal_class.__class__.__name__
-    
-    assert isinstance(otxc, str), "The otxc should be a string"
-    xc_base = fnal_class.otxc
-
-    ks = sanity_check_for_df(mc_or_mf_mol)
-    
-    if fnal_class_type == 'transfnal':
-        xc_base = xc_base[1:]
-        ks.xc = xc_base
-        org_transfnal = transfnal(ks)
-        new_func_class = redefine_transfnal (org_transfnal, otfnalperiodic)
-        del org_transfnal
-
-    elif fnal_class_type == 'ftransfnal':
-        xc_base = xc_base[2:]
-        ks.xc = xc_base
-        org_ftransfnal = ftransfnal(ks)
-        new_func_class = redefine_ftransfnal (org_ftransfnal, otfnalperiodic)
-        del org_transfnal
-    else:
-        raise ValueError ("The fnal class is not recognized")
-
-    logger.info(mol, 'Periodic OT-FNAL class is used')
-    return new_func_class
+__all__ = [
+    "_get_mol_or_cell",
+    "_get_transfnal",
+    "get_pbc_otfnal_gamma",
+    "otfnalperiodic",
+    "otfnalperiodic_gamma",
+    "periodicpdft",
+    "redefine_fnal",
+    "redefine_ftransfnal",
+    "redefine_transfnal",
+    "sanity_check_for_df",
+    "sanity_check_for_kpts",
+]

--- a/my_pyscf/mcpdft/otfnalperiodic.py
+++ b/my_pyscf/mcpdft/otfnalperiodic.py
@@ -20,17 +20,3 @@ from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import (
 otfnalperiodic = otfnalperiodic_gamma
 _get_transfnal = get_pbc_otfnal_gamma
 sanity_check_for_df = _get_ks_obj
-
-__all__ = [
-    "_get_mol_or_cell",
-    "_get_transfnal",
-    "get_pbc_otfnal_gamma",
-    "otfnalperiodic",
-    "otfnalperiodic_gamma",
-    "periodicpdft",
-    "redefine_fnal",
-    "redefine_ftransfnal",
-    "redefine_transfnal",
-    "sanity_check_for_df",
-    "sanity_check_for_kpts",
-]

--- a/my_pyscf/mcpdft/otfnalperiodic.py
+++ b/my_pyscf/mcpdft/otfnalperiodic.py
@@ -1,8 +1,4 @@
-"""Backward-compatible imports for periodic on-top functionals.
-
-Periodic MC-PDFT is implemented in :mod:`mrh.my_pyscf.pbc.mcpdft`.  This
-module retains the historical import paths used by downstream callers.
-"""
+# !/usr/bin/env python
 
 from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import (
     _get_ks_obj,
@@ -16,6 +12,14 @@ from mrh.my_pyscf.pbc.mcpdft.otfnalperiodic import (
     sanity_check_for_kpts,
 )
 
+# Author: Bhavnesh Jangid
+
+"""
+Backward-compatible imports for periodic on-top functionals.
+
+Periodic MC-PDFT is implemented in :mod:`mrh.my_pyscf.pbc.mcpdft`.  This
+module retains the historical import paths used by downstream callers.
+"""
 
 otfnalperiodic = otfnalperiodic_gamma
 _get_transfnal = get_pbc_otfnal_gamma

--- a/my_pyscf/pbc/mcpdft/__init__.py
+++ b/my_pyscf/pbc/mcpdft/__init__.py
@@ -132,25 +132,20 @@ def _laspdftEnergy(mc_class, mc_or_mf, ot, ncas_sub, nelecas_sub,
         if frozen is not None:
             las.frozen = frozen
     else:
-        las_kwargs = {
-            "ncore": ncore,
-            "spin_sub": spin_sub,
-        }
-        if frozen is not None:
-            las_kwargs["frozen"] = frozen
+        las_kwargs = {"ncore": ncore, "spin_sub": spin_sub, "frozen": frozen}
         las = mc_class(mc_or_mf, ncas_sub, nelecas_sub, **las_kwargs)
-
     return get_mcpdft_child_class(las, ot, **kwargs)
 
 
 def LASSCFPDFT(mc_or_mf, ot, ncas_sub=None, nelecas_sub=None, ncore=None,
                spin_sub=None, frozen=None, **kwargs):
-    """Create a gamma-point periodic LAS-PDFT solver."""
+    """
+    Create a gamma-point periodic LAS-PDFT solver.
+    """
     if ncas_sub is None:
         ncas_sub = getattr(mc_or_mf, "ncas_sub", None)
     if nelecas_sub is None:
         nelecas_sub = getattr(mc_or_mf, "nelecas_sub", None)
-
     from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF as MolecularLASSCF
     return _laspdftEnergy(
         MolecularLASSCF,

--- a/my_pyscf/pbc/mcpdft/__init__.py
+++ b/my_pyscf/pbc/mcpdft/__init__.py
@@ -31,23 +31,42 @@ def _sanity_check_for_kmf(kmf0):
     
     return kmf0
 
+
+def _sanity_check_for_gamma_mf(mf0):
+    """Validate a gamma-point mean-field object.
+
+    The historical gamma-point API accepted periodic HF and DFT references.
+    k-point MC-PDFT remains restricted to HF references.
+    """
+    assert isinstance(mf0, scf.hf.SCF), \
+        "MC-PDFT only works with periodic SCF objects"
+    if isinstance(mf0, scf.kuhf.KUHF):
+        mf0 = scf.addons.convert_to_rhf(mf0)
+    return mf0
+
 def _MCPDFT (mc_class, kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None,
             get_mcpdft_child_class=get_mcpdft_child_class,
+            sanity_check=_sanity_check_for_kmf, allow_frozen=False,
             **kwargs):
     kmf0 = getattr (kmc_or_kmf, '_scf', None)
     
     # If started with kCASCI or kCASSCF object, 
     if kmf0 is not None:
-        kmf0 = _sanity_check_for_kmf(kmf0)
+        kmf0 = sanity_check(kmf0)
         kmc0 = kmc_or_kmf
     else:
         kmf0 = kmc_or_kmf
-        kmf0 = _sanity_check_for_kmf(kmf0)
+        kmf0 = sanity_check(kmf0)
         kmc0 = None
 
-    assert frozen is None, "Frozen orbitals are not supported in k-MCPDFT yet."
-    kmc = get_mcpdft_child_class (mc_class (kmf0, ncas, nelecas, ncore=ncore),
-                                ot, **kwargs)
+    if frozen is not None and not allow_frozen:
+        raise NotImplementedError("Frozen orbitals are not supported in k-MC-PDFT")
+    mc_kwargs = {"ncore": ncore}
+    if frozen is not None:
+        mc_kwargs["frozen"] = frozen
+    kmc = get_mcpdft_child_class(
+        mc_class(kmf0, ncas, nelecas, **mc_kwargs), ot, **kwargs,
+    )
 
     if kmc0 is not None:
         from mrh.my_pyscf.pbc.mcscf.casci import PBCCASCI
@@ -66,12 +85,15 @@ def CASSCFPDFT(kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None, **kwargs)
     get_mcpdft_child_class = get_pbc_mcpdft_child_class_gamma
     return _MCPDFT(mcscf.CASSCF, kmc_or_kmf, ot, ncas, nelecas, ncore=ncore, frozen=frozen,
                     get_mcpdft_child_class=get_mcpdft_child_class,
+                    sanity_check=_sanity_check_for_gamma_mf,
+                    allow_frozen=True,
                 **kwargs)
 
 def CASCIPDFT(kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None, **kwargs):
     get_pbc_mcpdft_child_class = get_pbc_mcpdft_child_class_gamma
     return _MCPDFT(mcscf.CASCI, kmc_or_kmf, ot, ncas, nelecas, ncore=ncore, frozen=frozen,
                     get_mcpdft_child_class=get_pbc_mcpdft_child_class,
+                    sanity_check=_sanity_check_for_gamma_mf,
                 **kwargs)
 
 CASSCF = CASSCFPDFT

--- a/my_pyscf/pbc/mcpdft/__init__.py
+++ b/my_pyscf/pbc/mcpdft/__init__.py
@@ -88,3 +88,59 @@ def kCASCIPDFT(kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None, **kwargs)
 
 KCASSCF = kCASSCFPDFT
 KCASCI = kCASCIPDFT
+
+
+def _laspdftEnergy(mc_class, mc_or_mf, ot, ncas_sub, nelecas_sub,
+                   ncore=None, spin_sub=None, frozen=None, **kwargs):
+    from mrh.my_pyscf.mcscf.lasscf_sync_o0 import LASSCFNoSymm, LASSCFSymm
+    from mrh.my_pyscf.mcscf.lasscf_async import (
+        LASSCFNoSymm as AsyncLASSCFNoSymm,
+        LASSCFSymm as AsyncLASSCFSymm,
+    )
+    from mrh.my_pyscf.pbc.mcpdft.laspdft import get_mcpdft_child_class
+
+    las_classes = (
+        LASSCFNoSymm,
+        LASSCFSymm,
+        AsyncLASSCFNoSymm,
+        AsyncLASSCFSymm,
+    )
+    if isinstance(mc_or_mf, las_classes):
+        las = mc_or_mf
+        if frozen is not None:
+            las.frozen = frozen
+    else:
+        las_kwargs = {
+            "ncore": ncore,
+            "spin_sub": spin_sub,
+        }
+        if frozen is not None:
+            las_kwargs["frozen"] = frozen
+        las = mc_class(mc_or_mf, ncas_sub, nelecas_sub, **las_kwargs)
+
+    return get_mcpdft_child_class(las, ot, **kwargs)
+
+
+def LASSCFPDFT(mc_or_mf, ot, ncas_sub=None, nelecas_sub=None, ncore=None,
+               spin_sub=None, frozen=None, **kwargs):
+    """Create a gamma-point periodic LAS-PDFT solver."""
+    if ncas_sub is None:
+        ncas_sub = getattr(mc_or_mf, "ncas_sub", None)
+    if nelecas_sub is None:
+        nelecas_sub = getattr(mc_or_mf, "nelecas_sub", None)
+
+    from mrh.my_pyscf.mcscf.lasscf_o0 import LASSCF as MolecularLASSCF
+    return _laspdftEnergy(
+        MolecularLASSCF,
+        mc_or_mf,
+        ot,
+        ncas_sub,
+        nelecas_sub,
+        ncore=ncore,
+        spin_sub=spin_sub,
+        frozen=frozen,
+        **kwargs,
+    )
+
+
+LASSCF = LASSCFPDFT

--- a/my_pyscf/pbc/mcpdft/__init__.py
+++ b/my_pyscf/pbc/mcpdft/__init__.py
@@ -14,16 +14,13 @@ from mrh.my_pyscf.pbc.mcpdft.kmcpdft import get_mcpdft_child_class
 # and same code structure.
 
 def _sanity_check_for_kmf(kmf0):
-    '''
-    Wrapper function to check whether the input mean-field object is periodic SCF or not.
-    If it is k-DFT then convert that to the k-HF object.
-    '''
+    """Validate that the input is a periodic Hartree-Fock object."""
     assert isinstance(kmf0, scf.hf.SCF),  \
-        "k-MCPDFT only works with periodic SCF objects"
+        "PBC MC-PDFT only works with periodic SCF objects"
 
     if isinstance(kmf0, dft.krks.KRKS) or isinstance(kmf0, dft.kuks.KUKS) \
         or isinstance(kmf0, dft.rks.RKS) or isinstance(kmf0, dft.uks.UKS):
-        raise NotImplementedError("k-MCPDFT only works with periodic HF objects.")
+        raise NotImplementedError("PBC MC-PDFT only works with periodic HF objects.")
         # In this case, probably one need to regenerate the 3C integrals.
 
     if isinstance(kmf0, scf.kuhf.KUHF):
@@ -31,32 +28,18 @@ def _sanity_check_for_kmf(kmf0):
     
     return kmf0
 
-
-def _sanity_check_for_gamma_mf(mf0):
-    """Validate a gamma-point mean-field object.
-
-    The historical gamma-point API accepted periodic HF and DFT references.
-    k-point MC-PDFT remains restricted to HF references.
-    """
-    assert isinstance(mf0, scf.hf.SCF), \
-        "MC-PDFT only works with periodic SCF objects"
-    if isinstance(mf0, scf.kuhf.KUHF):
-        mf0 = scf.addons.convert_to_rhf(mf0)
-    return mf0
-
 def _MCPDFT (mc_class, kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None,
             get_mcpdft_child_class=get_mcpdft_child_class,
-            sanity_check=_sanity_check_for_kmf, allow_frozen=False,
-            **kwargs):
+            allow_frozen=False, **kwargs):
     kmf0 = getattr (kmc_or_kmf, '_scf', None)
     
     # If started with kCASCI or kCASSCF object, 
     if kmf0 is not None:
-        kmf0 = sanity_check(kmf0)
+        kmf0 = _sanity_check_for_kmf(kmf0)
         kmc0 = kmc_or_kmf
     else:
         kmf0 = kmc_or_kmf
-        kmf0 = sanity_check(kmf0)
+        kmf0 = _sanity_check_for_kmf(kmf0)
         kmc0 = None
 
     if frozen is not None and not allow_frozen:
@@ -85,7 +68,6 @@ def CASSCFPDFT(kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None, **kwargs)
     get_mcpdft_child_class = get_pbc_mcpdft_child_class_gamma
     return _MCPDFT(mcscf.CASSCF, kmc_or_kmf, ot, ncas, nelecas, ncore=ncore, frozen=frozen,
                     get_mcpdft_child_class=get_mcpdft_child_class,
-                    sanity_check=_sanity_check_for_gamma_mf,
                     allow_frozen=True,
                 **kwargs)
 
@@ -93,7 +75,6 @@ def CASCIPDFT(kmc_or_kmf, ot, ncas, nelecas, ncore=None, frozen=None, **kwargs):
     get_pbc_mcpdft_child_class = get_pbc_mcpdft_child_class_gamma
     return _MCPDFT(mcscf.CASCI, kmc_or_kmf, ot, ncas, nelecas, ncore=ncore, frozen=frozen,
                     get_mcpdft_child_class=get_pbc_mcpdft_child_class,
-                    sanity_check=_sanity_check_for_gamma_mf,
                 **kwargs)
 
 CASSCF = CASSCFPDFT

--- a/my_pyscf/pbc/mcpdft/laspdft.py
+++ b/my_pyscf/pbc/mcpdft/laspdft.py
@@ -1,20 +1,26 @@
-"""LAS-PDFT support for periodic gamma-point calculations."""
-
 from mrh.my_pyscf.mcpdft import laspdft as molecular_laspdft
 from mrh.my_pyscf.pbc.mcpdft.mcpdft import _MCPDFT
 
+# Author: Bhavnesh Jangid
+
+"""
+LAS-PDFT support for periodic gamma-point calculations.
+"""
 
 class _LASPDFT(_MCPDFT, molecular_laspdft._LASPDFT):
-    """Periodic MC-PDFT energy for a localized active-space wavefunction."""
-
+    """
+    Periodic MC-PDFT energy for a localized active-space wavefunction.
+    """
     @property
     def cell(self):
         return self._scf.cell
 
 
 def get_mcpdft_child_class(las, ot, DoLASSI=False, states=None, **kwargs):
-    """Combine a gamma-point LAS solver with periodic LAS-PDFT methods."""
-    return molecular_laspdft.get_mcpdft_child_class(
+    """
+    Combine a gamma-point LAS solver with periodic LAS-PDFT methods.
+    """
+    laspdft = molecular_laspdft.get_mcpdft_child_class(
         las,
         ot,
         DoLASSI=DoLASSI,
@@ -22,3 +28,4 @@ def get_mcpdft_child_class(las, ot, DoLASSI=False, states=None, **kwargs):
         _pdft_class=_LASPDFT,
         **kwargs,
     )
+    return laspdft

--- a/my_pyscf/pbc/mcpdft/laspdft.py
+++ b/my_pyscf/pbc/mcpdft/laspdft.py
@@ -1,0 +1,24 @@
+"""LAS-PDFT support for periodic gamma-point calculations."""
+
+from mrh.my_pyscf.mcpdft import laspdft as molecular_laspdft
+from mrh.my_pyscf.pbc.mcpdft.mcpdft import _MCPDFT
+
+
+class _LASPDFT(_MCPDFT, molecular_laspdft._LASPDFT):
+    """Periodic MC-PDFT energy for a localized active-space wavefunction."""
+
+    @property
+    def cell(self):
+        return self._scf.cell
+
+
+def get_mcpdft_child_class(las, ot, DoLASSI=False, states=None, **kwargs):
+    """Combine a gamma-point LAS solver with periodic LAS-PDFT methods."""
+    return molecular_laspdft.get_mcpdft_child_class(
+        las,
+        ot,
+        DoLASSI=DoLASSI,
+        states=states,
+        _pdft_class=_LASPDFT,
+        **kwargs,
+    )

--- a/my_pyscf/pbc/mcpdft/otfnalperiodic.py
+++ b/my_pyscf/pbc/mcpdft/otfnalperiodic.py
@@ -250,8 +250,8 @@ def _get_ks_obj(kmc_or_kmf_or_cell, khf=False, kpts=None):
     return ks
 
 
-def _get_pbc_otfnal(kmc_or_kmf_or_cell, otxc, otfnalperiodic_class, 
-                    cell_kptsinfo={}):
+def _get_pbc_otfnal(kmc_or_kmf_or_cell, otxc, otfnalperiodic_class,
+                    cell_kptsinfo=None):
     '''
     This is wrapper function to get the appropriate fnal class 
     for the given cell object
@@ -264,6 +264,9 @@ def _get_pbc_otfnal(kmc_or_kmf_or_cell, otxc, otfnalperiodic_class,
             otfnalperiodic class. This is a hack to avoid refactoring the whole code 
             to pass the cell and kpts only needed for the kpts calculations.
     '''
+    if cell_kptsinfo is None:
+        cell_kptsinfo = {}
+
     cell = _get_mol_or_cell (kmc_or_kmf_or_cell)
     fnal_class = get_transfnal (cell, otxc)
     fnal_class_type = fnal_class.__class__.__name__
@@ -317,3 +320,38 @@ def get_pbc_otfnal_kpts(kmc_or_kmf_or_cell, otxc):
     return _get_pbc_otfnal(kmc_or_kmf_or_cell, otxc, otfnalperiodic_kpts, 
                            cell_kptsinfo=cell_kptsinfo)
 
+
+def sanity_check_for_kpts(mc_or_mf_or_cell):
+    """Require the single k-point supported by gamma-point MC-PDFT."""
+    obj = mc_or_mf_or_cell
+    if hasattr(obj, "_las"):
+        obj = obj._las
+    if hasattr(obj, "_scf"):
+        obj = obj._scf
+
+    kpts = getattr(obj, "kpts", None)
+    if kpts is None:
+        raise NotImplementedError("The input object does not have kpts attribute")
+    if len(kpts) > 1:
+        raise ValueError("Only supercell calculations can be performed with MC-PDFT")
+
+
+def periodicpdft(mc_or_mf_or_mol, ot):
+    """Return the periodic gamma-point on-top functional when appropriate.
+
+    Molecular inputs are returned unchanged.  This behavior is retained for
+    callers of the historical ``mrh.my_pyscf.mcpdft.periodicpdft`` helper.
+    """
+    assert isinstance(ot, str), "The ot should be a string"
+    mol_or_cell = _get_mol_or_cell(mc_or_mf_or_mol)
+    if isinstance(mol_or_cell, pbcgto.cell.Cell):
+        sanity_check_for_kpts(mc_or_mf_or_mol)
+        return get_pbc_otfnal_gamma(mc_or_mf_or_mol, ot)
+    return ot
+
+
+# Historical names kept here so the compatibility module in
+# ``mrh.my_pyscf.mcpdft`` can be a thin re-export of the periodic code.
+otfnalperiodic = otfnalperiodic_gamma
+_get_transfnal = get_pbc_otfnal_gamma
+sanity_check_for_df = _get_ks_obj

--- a/my_pyscf/pbc/mcpdft/otfnalperiodic.py
+++ b/my_pyscf/pbc/mcpdft/otfnalperiodic.py
@@ -307,10 +307,21 @@ def get_pbc_otfnal_gamma(kmc_or_kmf_or_cell, otxc):
 def get_pbc_otfnal_kpts(kmc_or_kmf_or_cell, otxc):
     cell = _get_mol_or_cell (kmc_or_kmf_or_cell)
     kpts = getattr(kmc_or_kmf_or_cell, 'kpts', None)
-    kmesh = getattr(kmc_or_kmf_or_cell, 'kmesh', None)
+    try:
+        kmesh = getattr(kmc_or_kmf_or_cell, 'kmesh', None)
+    except TypeError:
+        # PySCF's SCF.kmesh property changed with the kpts_to_kmesh API.
+        kmesh = None
 
     assert kpts is not None, "kpts is required for kpts-based OT-FNAL"
-    assert kmesh is not None, "kmesh is required for kpts-based OT-FNAL"
+    if kmesh is None:
+        from pyscf.pbc.tools.k2gamma import kpts_to_kmesh
+        try:
+            kmesh = kpts_to_kmesh(cell, kpts)
+        except TypeError:
+            # Compatibility with PySCF releases whose helper accepted only
+            # the k-point array.
+            kmesh = kpts_to_kmesh(kpts)
 
     cell_kptsinfo = {
         'cell': cell, 

--- a/tests/pbc/test_pbc_laspdft.py
+++ b/tests/pbc/test_pbc_laspdft.py
@@ -15,7 +15,7 @@ class KnownValues(unittest.TestCase):
         cell.a = np.eye(3) * 8
         cell.atom = "H 0 0 0; H 1.4 0 0"
         cell.unit = "Bohr"
-        cell.basis = "sto-3g"
+        cell.basis = "6-31g"
         cell.precision = 1e-8
         cell.verbose = 0
         cell.build()
@@ -43,7 +43,7 @@ class KnownValues(unittest.TestCase):
         mc.kernel(mo)
 
         self.assertTrue(mc.converged)
-        self.assertAlmostEqual(mc.e_tot, -0.5329013391934931, 7)
+        self.assertAlmostEqual(mc.e_tot, -0.7389379476115105, 7)
 
     def test_legacy_laspdft_dispatch(self):
         from mrh.my_pyscf import mcpdft as legacy_mcpdft

--- a/tests/pbc/test_pbc_laspdft.py
+++ b/tests/pbc/test_pbc_laspdft.py
@@ -45,6 +45,36 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(mc.converged)
         self.assertAlmostEqual(mc.e_tot, -0.5329013391934931, 7)
 
+    def test_legacy_laspdft_dispatch(self):
+        from mrh.my_pyscf import mcpdft as legacy_mcpdft
+
+        mc = legacy_mcpdft.LASSCF(
+            self.mf,
+            "tPBE",
+            (1, 1),
+            (1, 1),
+            spin_sub=(2, 2),
+            grids_level=1,
+        )
+
+        self.assertIsInstance(mc, _LASPDFT)
+
+    def test_legacy_mcpdft_dispatch(self):
+        from mrh.my_pyscf import mcpdft as legacy_mcpdft
+        from mrh.my_pyscf.pbc.mcpdft.mcpdft import _MCPDFT
+
+        mc = legacy_mcpdft.CASCI(self.mf, "tPBE", 1, 2)
+
+        self.assertIsInstance(mc, _MCPDFT)
+
+    def test_legacy_periodic_imports(self):
+        from mrh.my_pyscf.mcpdft import otfnalperiodic as legacy
+        from mrh.my_pyscf.pbc.mcpdft import otfnalperiodic as periodic
+
+        self.assertIs(legacy.otfnalperiodic, periodic.otfnalperiodic_gamma)
+        self.assertIs(legacy._get_transfnal, periodic.get_pbc_otfnal_gamma)
+        self.assertIs(legacy.sanity_check_for_df, periodic._get_ks_obj)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pbc/test_pbc_laspdft.py
+++ b/tests/pbc/test_pbc_laspdft.py
@@ -1,0 +1,50 @@
+import unittest
+
+import numpy as np
+from pyscf.pbc import dft, gto, scf
+
+from mrh.my_pyscf.pbc import mcpdft
+from mrh.my_pyscf.pbc.mcpdft.laspdft import _LASPDFT
+
+
+class KnownValues(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cell = gto.Cell()
+        cell.a = np.eye(3) * 8
+        cell.atom = "H 0 0 0; H 1.4 0 0"
+        cell.unit = "Bohr"
+        cell.basis = "sto-3g"
+        cell.precision = 1e-8
+        cell.verbose = 0
+        cell.build()
+
+        mf = scf.RHF(cell).density_fit()
+        mf.exxdiv = None
+        mf.conv_tol = 1e-10
+        mf.kernel()
+        cls.mf = mf
+
+    def test_gamma_laspdft(self):
+        mc = mcpdft.LASSCF(
+            self.mf,
+            "tPBE",
+            (1, 1),
+            (1, 1),
+            spin_sub=(2, 2),
+            grids_level=1,
+        )
+
+        self.assertIsInstance(mc, _LASPDFT)
+        self.assertIsInstance(mc.grids, dft.gen_grid.BeckeGrids)
+
+        mo = mc.localize_init_guess(([0], [1]))
+        mc.kernel(mo)
+
+        self.assertTrue(mc.converged)
+        self.assertAlmostEqual(mc.e_tot, -0.5329013391934931, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pbc/test_pbc_pdft.py
+++ b/tests/pbc/test_pbc_pdft.py
@@ -75,7 +75,7 @@ class KnownValues(unittest.TestCase):
         )
 
     def test_mcpdft_gamma_point(self):
-        from mrh.my_pyscf import mcpdft
+        from mrh.my_pyscf.pbc import mcpdft
         cell = gto.M(a = np.eye(3)*5,
         atom = '''
             H         -6.37665        2.20769        3.00000

--- a/tests/pbc/test_pbc_pdft.py
+++ b/tests/pbc/test_pbc_pdft.py
@@ -86,15 +86,23 @@ class KnownValues(unittest.TestCase):
         cell.output = '/dev/null'
         cell.build()
 
-        mf = dft.RKS(cell).density_fit() # GDF
-        mf.xc = 'pbe'
+        mf = scf.RHF(cell).density_fit() # GDF
         mf.exxdiv = None
-        emf = mf.kernel()
+        mf.kernel()
+
+        ks = dft.RKS(cell).density_fit()
+        ks.xc = 'pbe'
+        ks.exxdiv = None
+        ks.max_cycle = 0
+        emf = ks.kernel(mf.make_rdm1())
 
         mc = mcpdft.CASCI(mf,'tPBE', 1, 2)
         ecasci = mc.kernel(mf.mo_coeff)[0]
 
         self.assertAlmostEqual (emf, ecasci, 7)
+
+        with self.assertRaisesRegex(NotImplementedError, "periodic HF"):
+            mcpdft.CASCI(ks, 'tPBE', 1, 2)
 
     def test_kmcpdft_limit_to_single_determinant(self):
         from mrh.my_pyscf.pbc import mcpdft


### PR DESCRIPTION
Currently, the Gamma point MC-PDFT, which was utilized in [this paper](https://www.nature.com/articles/s41467-025-65846-1) is at the `my_pyscf/mcpdft` while it should be part of `my_pyscf/pbc/mcpdft`. This PR address that.

Maintained the backward compatibility as well.